### PR TITLE
Google Maps API Key + Better SparkPost Usage

### DIFF
--- a/backend/backend-app.ts
+++ b/backend/backend-app.ts
@@ -87,7 +87,10 @@ app.set('sendMail', (function() {
         transport = nodemailerMockTransport();
         app.set('mailTransport', transport);
     } else if (config.sparkpost_api_key) {
-        transport = nodemailerSparkPostTransport({sparkPostApiKey: config.sparkpost_api_key});
+        transport = nodemailerSparkPostTransport({
+            sparkPostApiKey: config.sparkpost_api_key,
+            options: {click_tracking: false},
+        });
     } else {
         // Default: output to stdout only, don't actually send.
         logMessage = true;

--- a/backend/config.ts
+++ b/backend/config.ts
@@ -1,4 +1,7 @@
 // Environment and configuration
+import * as yaml from "js-yaml";
+import * as fs from "fs";
+
 export const environment: ('production'|'development'|'test') = (process.env.NODE_ENV as any) || 'development';
 export const config = (() => {
     let config = {
@@ -27,6 +30,12 @@ export const config = (() => {
             listen_port: 4444,
             db_name: 'boris_test',
         });
+    } else if (environment === 'development') {
+        // Allow overriding some config settings from a file (easier in dev environments)
+        const configOverridesPath = `${__dirname}/../../boris-private/dev-config.yml`;
+        if (fs.existsSync(configOverridesPath)) {
+            Object.assign(config, yaml.safeLoad(fs.readFileSync(configOverridesPath, 'utf8')));
+        }
     }
     if (process.env.BORIS_CONFIG) {
         Object.assign(config, JSON.parse(process.env.BORIS_CONFIG)[environment]);

--- a/frontend/auto-wayfinder/auto-wayfinder.tsx
+++ b/frontend/auto-wayfinder/auto-wayfinder.tsx
@@ -22,7 +22,7 @@ export class AutoWayfinder extends React.Component<Props> {
         return (
             <div className="auto-wayfinder-container">
                 <GoogleMapReact
-                    //bootstrapURLKeys={{key: 'api-key-here' }}
+                    bootstrapURLKeys={{key: 'AIzaSyACF7w2EwXqEZiPFvmctWPmOudRafG4sUc' }}
                     defaultCenter={{lat: this.props.lat, lng: this.props.lng}}
                     defaultZoom={this.props.zoom ? this.props.zoom : 15}
                     options={{


### PR DESCRIPTION
Adds Google Maps API Key

Disables SparkPost link rewriting.

Allows you to use a sparkpost API key locally by creating a folder called `boris-private` outside of the `boris` folder (next to it) and putting e.g. `sparkpost_api_key: 234567...` in a file called `dev-config.yml`