### PR TITLE
Deploy using Traefik for HTTPS + proxying

### DIFF
--- a/deploy/roles/app/defaults/main.yml
+++ b/deploy/roles/app/defaults/main.yml
@@ -2,7 +2,7 @@ boris_app_mode: production
 boris_app_domain: "something.apocalypsemadeeasy.com"
 boris_image_tag: "latest"
 boris_sparkpost_api_key: "{{ lookup('file', boris_deploy_private_dir + 'credentials/sparkpost_api_key') }}"
-boris_app_db_host: "{{boris_docker_network_host_ip}}"  # In order to be accessible to docker containers, spiped for the DB listens on this IP instead of 127.0.0.1
+boris_app_db_host: "{{traefik_docker_apps_network_host_ip}}"  # In order to be accessible to docker containers, spiped for the DB listens on this IP instead of 127.0.0.1
 boris_app_db_name: "boris_{{boris_instance_name}}"
 boris_app_db_user: "boris_{{boris_instance_name}}"
 boris_app_db_password: "{{ lookup('password', boris_deploy_private_dir + 'credentials/app_pgpassword length=15') }}"
@@ -10,9 +10,6 @@ boris_app_secret: "{{ lookup('password', boris_deploy_private_dir + 'credentials
 boris_app_environ_dir: "/etc/boris"
 boris_app_environ_file: "{{boris_app_environ_dir}}/{{boris_instance_name}}.env"
 
-boris_docker_network_name: boris-net
-boris_docker_network_subnet: 192.168.0.0/24
-boris_docker_network_host_ip: 192.168.0.1
 
 boris_config_base:
   app_domain: '{{ boris_app_domain }}'
@@ -21,11 +18,11 @@ boris_config_base:
   resource_url: '/s'
   sparkpost_api_key: "{{ boris_sparkpost_api_key }}"
   system_emails_from: "BORIS <info@apocalypsemadeeasy.com>"
-  redis_host: "{{ boris_docker_network_host_ip }}"
+  redis_host: "{{ traefik_docker_apps_network_host_ip }}"
   redis_port: "{{redis_secure_port}}"
   redis_password: "{{redis_password}}"
   redis_prefix: "boris:{{boris_instance_name}}:"
-  db_host: "{{ boris_docker_network_host_ip }}"
+  db_host: "{{ boris_app_db_host }}"
   db_port: "{{ postgres_secure_port }}"
   db_name: "{{ boris_app_db_name }}"
   db_user: "{{ boris_app_db_user }}"

--- a/deploy/roles/app/meta/main.yml
+++ b/deploy/roles/app/meta/main.yml
@@ -1,9 +1,13 @@
 ---
 dependencies:
   - { role: common }
+  - { role: traefik-load-balancer }
+  # Traefik load balancer must come before the database-common and redis-common
+  # roles, since the Traefik role creates the docker network that the spiped
+  # services then bind to.
   - role: database-common
-    postgres_secure_ip: "{{ boris_docker_network_host_ip }}"
+    postgres_secure_ip: "{{ traefik_docker_apps_network_host_ip }}"
   - role: redis-common
-    redis_secure_ip: "{{ boris_docker_network_host_ip }}"
+    redis_secure_ip: "{{ traefik_docker_apps_network_host_ip }}"
   - { role: geerlingguy-docker }
   - { role: docker-ansible }

--- a/deploy/roles/app/tasks/main.yml
+++ b/deploy/roles/app/tasks/main.yml
@@ -12,29 +12,6 @@
     owner: root
     mode: 600
 
-# Create docker network, so the containers can access each other and the host
-- name: Create Boris Docker network
-  docker_network:
-    name: "{{ boris_docker_network_name }}"
-    driver: bridge
-    ipam_options:
-      subnet: "{{ boris_docker_network_subnet }}"
-      gateway: "{{ boris_docker_network_host_ip }}"
-
-# Allow access from containers to spiped services on the host's virtual IP
-- name: Allow Docker containers to access redis on host's virtual IP
-  ufw:
-    rule: allow
-    port: "{{ redis_secure_port }}"
-    proto: tcp
-    from: "{{ boris_docker_network_subnet }}"
-- name: Allow Docker containers to access Postgres on host's virtual IP
-  ufw:
-    rule: allow
-    port: "{{ postgres_secure_port }}"
-    proto: tcp
-    from: "{{ boris_docker_network_subnet }}"
-
 # Postgresql Database
 - name: Configure database user for the app
   postgresql_user:
@@ -63,28 +40,25 @@
     login_password: "{{ database_postgres_admin_password }}"
     port: "{{ postgres_secure_port }}"
 
-# Create the boris container:
-- name: Configure Boris docker container
-  docker_container:
-    name: boris
-    image: "fromthestorm/boris:{{ boris_image_tag }}"
-    state: started
-    restart: yes
-    ports:
-      - "80:3333"
-    networks:
-        - name: "{{ boris_docker_network_name }}"
-    env_file: "{{ boris_app_environ_file }}"
+- name: Install docker-compose file
+  template:
+    src: docker-compose.yml.j2
+    dest: "{{boris_app_environ_dir}}/docker-compose.yml"
+    owner: root
+
+- name: Enable the BORIS Docker service
+  docker_service:
+    project_src: "{{boris_app_environ_dir}}"
+    project_name: boris
+    state: present
 
 # Run migrations
 - name: Run migrations
   command: docker exec boris node /app/backend/db/migrate.js
 # Restart container (rquired after new tables created in migrations)
 - name: Restart boris so massive-js will pick up new DB tables
-  command: docker restart boris
-
-- name: Allow access on port 80 (until we set up a load balancer with HTTPS etc.)
-  ufw:
-    rule: allow
-    port: 80
-    proto: tcp
+  docker_service:
+    project_src: "{{boris_app_environ_dir}}"
+    project_name: boris
+    state: present
+    restarted: yes

--- a/deploy/roles/app/templates/docker-compose.yml.j2
+++ b/deploy/roles/app/templates/docker-compose.yml.j2
@@ -1,0 +1,24 @@
+version: '2'
+
+services:
+  boris:
+    image: fromthestorm/boris:{{ boris_image_tag }}
+    restart: always
+    expose:
+      - 3333
+    networks:
+      - {{ traefik_docker_apps_network_name }}
+      - default
+    container_name: boris
+    env_file: 
+      - {{ boris_app_environ_file }}
+    labels:
+      - "traefik.docker.network={{ traefik_docker_apps_network_name }}"
+      - "traefik.enable=true"
+      - "traefik.basic.frontend.rule=Host:{{boris_app_domain}}"
+      - "traefik.basic.port=3333"
+      - "traefik.basic.protocol=http"
+
+networks:
+  {{traefik_docker_apps_network_name}}:
+    external: true

--- a/deploy/roles/docker-ansible/tasks/main.yml
+++ b/deploy/roles/docker-ansible/tasks/main.yml
@@ -6,3 +6,6 @@
 - name: Install docker python package
   pip:
     name: docker
+- name: Install docker-compose python package
+  pip:
+    name: docker-compose

--- a/deploy/roles/traefik-load-balancer/defaults/main.yml
+++ b/deploy/roles/traefik-load-balancer/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# Set these:
+#traefik_default_domain: myapp.com
+#traefik_acme_email: name@example.com
+traefik_use_lets_encrypt: yes
+traefik_docker_apps_network_name: web
+traefik_docker_apps_network_subnet: 192.168.0.0/24
+traefik_docker_apps_network_host_ip: 192.168.0.1
+
+traefik_config_dir: /etc/traefik
+traefik_version: 1.6.4

--- a/deploy/roles/traefik-load-balancer/meta/main.yml
+++ b/deploy/roles/traefik-load-balancer/meta/main.yml
@@ -1,0 +1,5 @@
+---
+dependencies:
+  - { role: common }
+  - { role: geerlingguy-docker }
+  - { role: docker-ansible }

--- a/deploy/roles/traefik-load-balancer/tasks/main.yml
+++ b/deploy/roles/traefik-load-balancer/tasks/main.yml
@@ -1,0 +1,57 @@
+---
+- name: Create Docker network for apps
+  docker_network:
+    name: "{{ traefik_docker_apps_network_name }}"
+    driver: bridge
+    ipam_options:
+      subnet: "{{ traefik_docker_apps_network_subnet }}"
+      gateway: "{{ traefik_docker_apps_network_host_ip }}"
+# Allow access from containers to services on the host's virtual IP
+- name: Allow access from containers to services on the host's virtual IP
+  ufw:
+    rule: allow
+    proto: tcp
+    from: "{{ traefik_docker_apps_network_subnet }}"
+
+- name: Create Traefik configuration directory
+  file:
+    path: "{{ traefik_config_dir }}"
+    state: directory
+    owner: root
+    mode: 0700
+
+- name: Install docker-compose file
+  template:
+    src: docker-compose.yml.j2
+    dest: "{{traefik_config_dir}}/docker-compose.yml"
+    owner: root
+
+- name: Ensure ACME status file exists
+  file:
+    path: "{{ traefik_config_dir }}/acme.json"
+    state: touch
+    owner: root
+    mode: 0600
+
+- name: Install Traefik configuration file
+  template:
+    src: traefik.toml.j2
+    dest: "{{traefik_config_dir}}/traefik.toml"
+    owner: root
+
+- name: Enable the Traefik Docker service
+  docker_service:
+    project_src: "{{traefik_config_dir}}"
+    state: present
+
+- name: Allow access on port 80
+  ufw:
+    rule: allow
+    port: 80
+    proto: tcp
+
+- name: Allow access on port 443
+  ufw:
+    rule: allow
+    port: 443
+    proto: tcp

--- a/deploy/roles/traefik-load-balancer/templates/docker-compose.yml.j2
+++ b/deploy/roles/traefik-load-balancer/templates/docker-compose.yml.j2
@@ -1,0 +1,20 @@
+version: '2'
+
+services:
+  traefik:
+    image: traefik:{{traefik_version}}
+    restart: always
+    ports:
+      - 80:80
+      - 443:443
+    networks:
+      - {{traefik_docker_apps_network_name}}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - {{traefik_config_dir}}/traefik.toml:/traefik.toml
+      - {{traefik_config_dir}}/acme.json:/acme.json
+    container_name: traefik
+
+networks:
+  {{traefik_docker_apps_network_name}}:
+    external: true

--- a/deploy/roles/traefik-load-balancer/templates/traefik.toml.j2
+++ b/deploy/roles/traefik-load-balancer/templates/traefik.toml.j2
@@ -1,0 +1,33 @@
+debug = false
+
+logLevel = "ERROR"
+defaultEntryPoints = [{% if traefik_use_lets_encrypt %}"https",{% endif %}"http"]
+
+[entryPoints]
+  [entryPoints.http]
+  address = ":80"
+{% if traefik_use_lets_encrypt %}
+    [entryPoints.http.redirect]
+    entryPoint = "https"
+  [entryPoints.https]
+  address = ":443"
+  [entryPoints.https.tls]
+{% endif %}
+
+[retry]
+
+[docker]
+endpoint = "unix:///var/run/docker.sock"
+domain = "{{traefik_default_domain}}"
+watch = true
+exposedByDefault = false
+
+{% if traefik_use_lets_encrypt %}
+[acme]
+email = "{{traefik_acme_email}}"
+storage = "acme.json"
+entryPoint = "https"
+onHostRule = true
+[acme.httpChallenge]
+entryPoint = "http"
+{% endif %}


### PR DESCRIPTION
This uses Træfik to get a Let's Encrypt HTTPS certificate, so we don't need to rely on CloudFlare HTTPS. This prevents unencrypted data from passing between Cloudflare's servers (which could be outside of Canada) and our Toronto servers.