### PR TITLE
Fix minor bug when a user has multiple simultaneous connections

### DIFF
--- a/backend/config.ts
+++ b/backend/config.ts
@@ -29,6 +29,7 @@ export const config = (() => {
             app_domain: 'localhost:4444',
             listen_port: 4444,
             db_name: 'boris_test',
+            redis_prefix: 'boris_test:',
         });
     } else if (environment === 'development') {
         // Allow overriding some config settings from a file (easier in dev environments)

--- a/backend/test-lib/utils.ts
+++ b/backend/test-lib/utils.ts
@@ -103,14 +103,17 @@ export class TestClient {
     }
     async registerAndLogin() {
         const userData = await this.registerUser();
-        await this.callApi(REQUEST_LOGIN, {email: userData.email});
+        await this.loginAs(userData.email);
+        return userData;
+    }
+    async loginAs(email: string) {
+        await this.callApi(REQUEST_LOGIN, {email});
 
         const transport: any = app.get('mailTransport');
-        const mailWithLink = transport.sentMail.filter((mail: any) => mail.data.to.indexOf(`<${userData.email}>`) !== -1)[0];
+        const mailWithLink = transport.sentMail.filter((mail: any) => mail.data.to.indexOf(`<${email}>`) !== -1)[0];
         const mailText: string = mailWithLink.data.html;
         const code = mailText.match(/login\/([\w\-]*)/)[1]
         await this.httpClient.get(`/auth/login/${code}`);
-        return userData;
     }
     /** Open an RPC Client connection to the server. You must close this afterward with client.close() */
     async openWebsocket(): Promise<any> {

--- a/backend/websocket/connections-test.ts
+++ b/backend/websocket/connections-test.ts
@@ -1,0 +1,64 @@
+import 'jest';
+import { TestServer, TestClient } from '../test-lib/utils';
+import { isUserOnline } from './online-users';
+
+describe("Websocket connection tests", () => {
+    let server: TestServer;
+    beforeAll(async () => {
+        server = new TestServer();
+        await server.ready();
+    });
+    afterAll(async () => {
+        await server.close();
+    });
+    describe("User online status", async () => {
+        it("Shows a user as online while their websocket is open", async () => {
+            const client = new TestClient(server);
+            const user = await client.registerAndLogin();
+
+            expect(await isUserOnline(user.id)).toBe(false);
+
+            const ws = await client.openWebsocket();
+
+            expect(await isUserOnline(user.id)).toBe(true);
+
+            await ws.close();
+            // We have no way to properly wait for the server to process the close event, so do our best:
+            await new Promise(r => setTimeout(r, 100));
+
+            expect(await isUserOnline(user.id)).toBe(false);
+        });
+
+        it("Shows a user as online when they have multiple websockets open", async () => {
+            const client1 = new TestClient(server);
+            const client2 = new TestClient(server);
+            const user = await client1.registerAndLogin();
+            await client2.loginAs(user.email);
+
+            expect(await isUserOnline(user.id)).toBe(false);
+
+            const ws1 = await client1.openWebsocket();
+
+            expect(await isUserOnline(user.id)).toBe(true);
+
+            const ws2 = await client2.openWebsocket();
+
+            // Allow the server to process any events:
+            await new Promise(r => setTimeout(r, 100));
+
+            expect(await isUserOnline(user.id)).toBe(true);
+        
+            // We close one websocket, but the user should still
+            // be marked as online, since the second will stay open:
+            await ws1.close();
+            await new Promise(r => setTimeout(r, 100));
+
+            expect(await isUserOnline(user.id)).toBe(true);
+
+            await ws2.close();
+            await new Promise(r => setTimeout(r, 100));
+
+            expect(await isUserOnline(user.id)).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
If a user had two websockets open and closed one, they'd appear offline for ~1 min.

Also fixes an issue where the tests weren't using an isolated redis prefix.