### PR TITLE
Update game state on disconnect

### DIFF
--- a/backend/routes/admin-api-test.ts
+++ b/backend/routes/admin-api-test.ts
@@ -235,14 +235,17 @@ describe("Admin API tests", () => {
             });
 
             it("Can edit an existing script", async () => {
-                const oldYaml = (await client.callApi(GET_SCRIPT, {id: EXISTING_SCRIPT_ID})).script_yaml;
+                const newScriptId = 'new-script35';
+                await client.callApi(CREATE_SCRIPT, {name: newScriptId, script_yaml: '[]'});
+
+                const oldYaml = (await client.callApi(GET_SCRIPT, {id: newScriptId})).script_yaml;
                 expect(oldYaml).not.toEqual(MINIMAL_SCRIPT);
-                const response = await client.callApi(EDIT_SCRIPT, {id: EXISTING_SCRIPT_ID, script_yaml: MINIMAL_SCRIPT});
+                const response = await client.callApi(EDIT_SCRIPT, {id: newScriptId, script_yaml: MINIMAL_SCRIPT});
                 expect(response).toEqual({
-                    name: EXISTING_SCRIPT_ID,
+                    name: newScriptId,
                     script_yaml: MINIMAL_SCRIPT,
                 });
-                const newYaml = (await client.callApi(GET_SCRIPT, {id: EXISTING_SCRIPT_ID})).script_yaml;
+                const newYaml = (await client.callApi(GET_SCRIPT, {id: newScriptId})).script_yaml;
                 expect(newYaml).toEqual(MINIMAL_SCRIPT);
             });
 

--- a/common/api.ts
+++ b/common/api.ts
@@ -126,6 +126,7 @@ export const START_GAME: ApiMethod<StartGameRequest, GameStatus> = {path: '/api/
 
 /** GET_UI_STATE Request */
 export interface GetUiStateResponse {
+    gameStatus: GameStatus;
     uiUpdateSeqId: number;
     state: AnyUiState[];
 }

--- a/frontend/rpc-client/manager.ts
+++ b/frontend/rpc-client/manager.ts
@@ -6,6 +6,7 @@ import { UserStateActions } from "../global/state/user-state-actions";
 import { RpcClientConnectionStatus, Actions } from "./rpc-client-actions";
 import { handleNotification } from "./notifications";
 import { Store } from "react-redux";
+import { refreshGameUiState } from "../global/state/game-state-actions";
 
 const client = new Client((location.protocol === 'http:' ? 'ws:' : 'wss:') + `//${location.host}/rpc`);
 
@@ -67,6 +68,8 @@ export function rpcClientMiddleware(store: MiddlewareAPI<RootState>) {
     client.on('notification', (notification: any) => {
         if (notification.method === 'connection_ready' && store.getState().rpcClientState.wantConnection) {
             store.dispatch<AnyAction>({type: Actions.WSCS_AVAILABLE});
+            // In case a game has started/stopped/updated while we were disconnected:
+            store.dispatch(refreshGameUiState());
             console.log("CONNECTION READY");
         } else {
             handleNotification(store as Store<RootState>, notification.params);

--- a/frontend/rpc-client/manager.ts
+++ b/frontend/rpc-client/manager.ts
@@ -69,7 +69,9 @@ export function rpcClientMiddleware(store: MiddlewareAPI<RootState>) {
         if (notification.method === 'connection_ready' && store.getState().rpcClientState.wantConnection) {
             store.dispatch<AnyAction>({type: Actions.WSCS_AVAILABLE});
             // In case a game has started/stopped/updated while we were disconnected:
-            store.dispatch(refreshGameUiState());
+            if (store.getState().teamState.hasJoinedTeam) { // The API call will return an error if we're not even on a team, so only check if we are.
+                store.dispatch(refreshGameUiState());
+            }
             console.log("CONNECTION READY");
         } else {
             handleNotification(store as Store<RootState>, notification.params);


### PR DESCRIPTION
If anything about the game changed while a phone is asleep or not connected, the phone would not update correctly when woken up. This fixes that by explicitly checking the state of the game with the server whenever a websocket connection is reestablished. 