### PR TITLE
Step that can award saltines

### DIFF
--- a/backend/backend-app.ts
+++ b/backend/backend-app.ts
@@ -8,7 +8,6 @@ import * as nodemailerMockTransport from 'nodemailer-mock-transport';
 import * as passport from 'passport';
 import {Strategy as UniqueTokenStrategy} from 'passport-unique-token';
 import * as path from 'path';
-import * as redis from 'redis';
 import * as session from 'express-session';
 import * as connectRedis from 'connect-redis';
 import * as whiskers from 'whiskers';
@@ -21,6 +20,7 @@ import {router as appAPIRouter} from './routes/app-api';
 import {router as loginRegisterRouter} from './routes/login-register';
 import {router as lobbyRouter} from './routes/lobby-api';
 import {router as gameRouter} from './routes/game-api';
+import {router as marketRouter} from './routes/market-api';
 import {router as testHelperRouter} from './routes/test-helper-api';
 import {router as appAdminRouter} from './routes/admin-api';
 import { subscribeToRedis, getPubSubClient } from './websocket/pub-sub';
@@ -174,6 +174,9 @@ app.use('/api/lobby', lobbyRouter);
 
 // Game API
 app.use('/api/game', gameRouter);
+
+// Market API
+app.use('/api/market', marketRouter);
 
 // Misc. API used by the single page app frontend:
 app.use('/api/app', appAPIRouter);

--- a/backend/db/schema/test-data.sql
+++ b/backend/db/schema/test-data.sql
@@ -54,6 +54,23 @@ INSERT INTO scripts (name, script_yaml) VALUES
     - This is sent to the doomsayer
 - step: target
   name: end
+'),
+
+('test-saltines-script', '---
+- step: award
+  earned: 5
+  possible: 10
+- step: choice
+  key: chooseXtoContinue
+  choices:
+    - x: Done
+- step: award
+  earned: 6
+  possible: 6
+- step: choice
+  key: chooseXtoEndGame
+  choices:
+    - x: Done
 ')
 
 ;

--- a/backend/game/manager.ts
+++ b/backend/game/manager.ts
@@ -659,7 +659,7 @@ export class GameManager implements GameManagerStepInterface {
     }
     private async _setTeamVar<T>(variable: Readonly<GameVar<T>>, updater: (value: T) => T) {
         const startTime = +new Date();
-        const result = this.db.instance.tx('update_team_var', async (task) => {
+        const result = await this.db.instance.tx('update_team_var', async (task) => {
             // Acquire a lock on the specific variable we're about to update, then call the updater
             // method, then save the result. This enables atomic increments, etc.
             // We use [game ID, 't' + var key] as a custom lock. This is because if we lock the whole

--- a/backend/game/script-loader.ts
+++ b/backend/game/script-loader.ts
@@ -5,10 +5,12 @@ import { VoidGameManager } from "./manager";
 import { SafeError } from "../routes/api-utils";
 
 
+let nextIfContextId = 1000;
+
 /**
  * Load a script by name. Loads from the database unless a YAML string is passed.
- * Parses and evaluates 'include' directives, but doesn't actually validate or
- * parse/load the normal script steps.
+ * Parses and evaluates 'include' and 'if/elif/else:then:' directives, but doesn't
+ * actually validate or parse/load the normal script steps.
  * @param db The database
  * @param scriptName The name of the script to load
  * @param scriptYamlString If a script YAML string is passed, use that instead of loading from the DB
@@ -32,10 +34,32 @@ async function _loadScript(db: BorisDatabase, scriptName: string, scriptYamlStri
         console.error(`Script ${scriptName} format is invalid: Expected root object to be an array.`);
         throw new SafeError(`Script ${scriptName} format is invalid.`);
     }
+    return _parseEntries(parsedData, db);
+}
+
+/**
+ * Parses and evaluates 'include' and 'if/elif/else:then:' directives, but doesn't
+ * actually validate or parse/load the normal script steps.
+ * Returns a single combined array of objects that each represent a Step
+ */
+async function _parseEntries(stepsData: any[], db: BorisDatabase) {
     // Now generate our result by collecting each entry in the script file, and recursively
     // loading any 'include: otherFile' entries.
     const result: any[] = [];
-    for (const entry of parsedData) {
+    let ifThenContextId: number|null = null; // This is a unique ID when we're parsing 'if/elif/else:then:' directives,
+                                             // not to be confused with 'if' conditions on individual steps.
+
+    // Call this from anywhere that may be adding steps after an if/elif/else directive.
+    // This will inject the important '-step: target, name: endOfContext...' step used
+    // by the rewritten if/elif/else directive.
+    const endAnyIfThenContext = () => {
+        if (ifThenContextId !== null) {
+            result.push({step: 'target', name: `endOfContext${ifThenContextId}`});
+            ifThenContextId = null;
+        }
+    }
+
+    for (const entry of stepsData) {
         if (typeof entry !== 'object' || Array.isArray(entry)) {
             console.error("This step's format is invalid: \n" + yaml.dump(entry));
             throw new Error("Encountered a step with invalid format");
@@ -46,12 +70,55 @@ async function _loadScript(db: BorisDatabase, scriptName: string, scriptYamlStri
             if (Object.keys(entry).length !== 1) {
                 throw new SafeError("Unexpected 'include' keyword in step.");
             }
+            endAnyIfThenContext();
             const includedScriptEntries = await loadScript(db, entry.include);
             Array.prototype.push.apply(result, includedScriptEntries);
+        } else if ('then' in entry) {
+            if ('if' in entry) {
+                endAnyIfThenContext();
+                ifThenContextId = ++nextIfContextId;
+            }
+            // This is an if/then, elif/then, or else/then directive,
+            // which has its own set of indented steps that we'll rewrite into
+            // a series of goto/target directives.
+            const gotoEndStep = {step: 'goto', name: `endOfContext${ifThenContextId}`};
+            const checkNextConditionTarget = {step: 'target', name: `nextCheck${ifThenContextId}`};
+            if (Object.keys(entry).length > 2) {
+                throw new SafeError('An if directive must have only two keys: "if/elif/else" and "then"');
+            }
+            if ('if' in entry) {
+                // Goto the next elif/else if this evaluates false.
+                result.push({step: 'goto', name: checkNextConditionTarget.name, if: `!(${entry.if})`});
+                const childSteps = await _parseEntries(entry.then, db);
+                Array.prototype.push.apply(result, childSteps);
+                result.push(gotoEndStep);
+                result.push(checkNextConditionTarget);
+            } else if ('elif' in entry) {
+                if (ifThenContextId === null) {
+                    throw new SafeError("Can't have an 'elif' that's not following an if/then directive.");
+                }
+                // Goto the next elif/else if this evaluates false.
+                result.push({step: 'goto', name: checkNextConditionTarget.name, if: `!(${entry.elif})`});
+                const childSteps = await _parseEntries(entry.then, db);
+                Array.prototype.push.apply(result, childSteps);
+                result.push(gotoEndStep);
+                result.push(checkNextConditionTarget);
+            } else if ('else' in entry) {
+                if (ifThenContextId === null) {
+                    throw new SafeError("Can't have an 'else' that's not following an if/then directive.");
+                }
+                const childSteps = await _parseEntries(entry.then, db);
+                Array.prototype.push.apply(result, childSteps);
+                endAnyIfThenContext();
+            } else {
+                throw new SafeError('Invalid keyword combined with "then". Did you mean if/elif/else ?');
+            }
         } else {
+            endAnyIfThenContext();
             result.push(entry);
         }
     }
+    endAnyIfThenContext();
     return result;
 }
 

--- a/backend/game/steps/award-saltines-integration-test.ts
+++ b/backend/game/steps/award-saltines-integration-test.ts
@@ -1,0 +1,109 @@
+import 'jest';
+import { BorisDatabase, getDB } from '../../db/db';
+import { GameManager } from '../manager';
+import { createTeam } from '../../test-lib/test-data';
+import { DBScenario } from '../../db/models';
+import { AnyNotification } from '../../../common/notifications';
+import { StepType } from '../../../common/game';
+import { getSaltinesStatus, getSaltinesEarnedInGame } from './award-saltines';
+
+async function sendXtoCurrentChoiceStep(manager: GameManager, userId = manager.playerIds[0]) {
+    const stepsSeen = manager.getUiStateForUser(userId);
+    const currentStep = stepsSeen[stepsSeen.length - 1];
+    expect(currentStep.type).toEqual(StepType.MultipleChoice);
+    await manager.callStepHandler({stepId: currentStep.stepId, choiceId: 'x'});
+    await manager.allPendingStepsFlushed();
+}
+
+describe("Award Saltines Integration tests", () => {
+    let db: BorisDatabase;
+    let scenario: DBScenario;
+    let testContext: {db: BorisDatabase, publishEventToUsers: (userIds: number[], event: AnyNotification) => void};
+    let teamId: number; 
+    beforeAll(async () => {
+        db = await getDB();
+        scenario = (await db.scenarios.insert({
+            is_active: true,
+            name: "Test Scenario",
+            script: 'test-saltines-script',
+        }));
+        teamId = (await createTeam(db, 3)).teamId;
+        testContext = {
+            db: db,
+            publishEventToUsers: (userIds: number[], event: AnyNotification) => {},
+        }
+    });
+    afterAll(async () => {
+        await db.instance.$pool.end();
+    });
+
+    it("Shows the team as having no saltines earned at first", async () => {
+        expect(await getSaltinesStatus(teamId, db)).toEqual({
+            earned: 0,
+            spent: 0,
+            balance: 0,
+        });
+    });
+
+    it("Shows the team as having 5 of 10 saltines halfway through the game and 11 of 16 when done", async () => {
+        const {manager, status} = await GameManager.startGame(teamId, scenario.id, testContext);
+        await manager.allPendingStepsFlushed();
+        expect(getSaltinesEarnedInGame(manager)).toEqual({
+            earnedThisGame: 5,
+            possibleThisGame: 10,
+        });
+        expect(await getSaltinesStatus(teamId, db)).toEqual({
+            earned: 5,
+            spent: 0,
+            balance: 5,
+        });
+        await sendXtoCurrentChoiceStep(manager);
+        expect(getSaltinesEarnedInGame(manager)).toEqual({
+            earnedThisGame: 11,
+            possibleThisGame: 16,
+        });
+        expect(await getSaltinesStatus(teamId, db)).toEqual({
+            earned: 11,
+            spent: 0,
+            balance: 11,
+        });
+        expect(manager.gameActive).toBe(true);
+        await sendXtoCurrentChoiceStep(manager);
+        expect(manager.gameActive).toBe(false);
+        // The game is now complete:
+        expect(getSaltinesEarnedInGame(manager)).toEqual({
+            earnedThisGame: 11,
+            possibleThisGame: 16,
+        });
+        expect(await getSaltinesStatus(teamId, db)).toEqual({
+            earned: 11,
+            spent: 0,
+            balance: 11,
+        });
+    });
+
+    it("Reverts the saltines awarded if the game is abandoned", async () => {
+        expect(await getSaltinesStatus(teamId, db)).toEqual({
+            earned: 11,
+            spent: 0,
+            balance: 11,
+        });
+        const {manager, status} = await GameManager.startGame(teamId, scenario.id, testContext);
+        await manager.allPendingStepsFlushed();
+        expect(getSaltinesEarnedInGame(manager)).toEqual({
+            earnedThisGame: 5,
+            possibleThisGame: 10,
+        });
+        expect(await getSaltinesStatus(teamId, db)).toEqual({
+            earned: 11 + 5,
+            spent: 0,
+            balance: 11 + 5,
+        });
+        await manager.abandon();
+        expect(await getSaltinesStatus(teamId, db)).toEqual({
+            earned: 11,
+            spent: 0,
+            balance: 11,
+        });
+    });
+});

--- a/backend/game/steps/award-saltines.ts
+++ b/backend/game/steps/award-saltines.ts
@@ -1,0 +1,70 @@
+import { StepType } from "../../../common/game";
+import { SafeError } from "../../routes/api-utils";
+import { Step } from "../step";
+import { GameVar, GameVarScope } from "../vars";
+import { getTeamVar } from "../team-vars";
+import { BorisDatabase } from "../../db/db";
+import { GameManager } from "../manager";
+
+interface AwardSaltinesStepSettings {
+    earned: number,
+    possible: number,
+};
+
+export const SALTINES_EARNED_ALL_TIME: GameVar<number> = {key: 'saltines', scope: GameVarScope.Team, default: 0};
+export const SALTINES_SPENT: GameVar<number> = {key: 'saltines_spent', scope: GameVarScope.Team, default: 0};
+export const SALTINES_EARNED_THIS_GAME: GameVar<number> = {key: 'saltines_this_game', scope: GameVarScope.Game, default: 0};
+export const SALTINES_POSSIBLE_THIS_GAME: GameVar<number> = {key: 'possible_saltines_this_game', scope: GameVarScope.Game, default: 0};
+
+export async function getSaltinesStatus(teamId: number, db: BorisDatabase) {
+    const earned = await getTeamVar(SALTINES_EARNED_ALL_TIME, teamId, db);
+    const spent = await getTeamVar(SALTINES_SPENT, teamId, db);
+    return {
+        balance: earned - spent,
+        earned,
+        spent,
+    }
+}
+export function getSaltinesEarnedInGame(gameManager: GameManager) {
+    const earnedThisGame = gameManager.getVar(SALTINES_EARNED_THIS_GAME);
+    const possibleThisGame = gameManager.getVar(SALTINES_POSSIBLE_THIS_GAME);
+    return {
+        earnedThisGame,
+        possibleThisGame,
+    }
+}
+
+export class AwardSaltinesStep extends Step {
+    public static readonly stepType: StepType = StepType.Internal;
+    readonly settings: AwardSaltinesStepSettings;
+
+    async run() {
+        this.setVar(SALTINES_EARNED_ALL_TIME, oldAmount => oldAmount + this.settings.earned);
+        this.setVar(SALTINES_EARNED_THIS_GAME, oldAmount => oldAmount + this.settings.earned);
+        this.setVar(SALTINES_POSSIBLE_THIS_GAME, oldAmount => oldAmount + this.settings.possible);
+    }
+
+    protected parseConfig(config: any): AwardSaltinesStepSettings {
+        if (typeof config.earned !== 'number') {
+            throw new SafeError("Award saltines step must have a numeric 'earned' parameter");
+        }
+        if (typeof config.possible !== 'number') {
+            throw new SafeError("Award saltines step must have a numeric 'possible' parameter");
+        }
+        if (config.earned > config.possible) {
+            throw new SafeError("Earned must be less than or equal to possible.");
+        }
+        return {
+            earned: config.earned,
+            possible: config.possible,
+        }
+    }
+
+    getUiState(): null {
+        return null;
+    }
+
+    public get isComplete() {
+        return true;
+    }
+}

--- a/backend/game/steps/loader.ts
+++ b/backend/game/steps/loader.ts
@@ -9,6 +9,7 @@ import { GotoStep } from "./goto-step";
 import { TargetStep } from "./target-step";
 import { AssignRolesStep } from "./assign-roles";
 import { BulletinStep } from "./bulletin";
+import { AwardSaltinesStep } from "./award-saltines";
 
 export function loadStepFromData(data: any, id: number, manager: GameManagerStepInterface): Step {
     const {step, ...otherData} = data; // Remove the 'step' key from the data; 'step' is the step type.
@@ -20,6 +21,7 @@ export function loadStepFromData(data: any, id: number, manager: GameManagerStep
         case 'pause': return new PauseStep(args);
         case 'goto': return new GotoStep(args);
         case 'target': return new TargetStep(args);
+        case 'award': return new AwardSaltinesStep(args);
         case 'bulletin': return new BulletinStep(args);
         case 'assignroles': return new AssignRolesStep(args);
         default: throw new Error(`Unable to load type with step type "${step}".`);

--- a/backend/routes/market-api.ts
+++ b/backend/routes/market-api.ts
@@ -1,0 +1,34 @@
+/**
+ * Routes for interacting with the market
+ */
+import * as express from 'express';
+
+import { BorisDatabase } from '../db/db';
+import { GET_SALTINES_BALANCE } from '../../common/api';
+import { makeApiHelper, RequireUser, SafeError } from './api-utils';
+import { getSaltinesStatus } from '../game/steps/award-saltines';
+
+export const router = express.Router();
+
+const apiMethod = makeApiHelper(router, /^\/api\/market/, RequireUser.Required);
+
+async function requireActiveTeamMembership(db: BorisDatabase, userId: number) {
+    const activeTeamMembership = await db.team_members.findOne({user_id: userId, is_active: true});
+    if (activeTeamMembership === null) {
+        throw new SafeError("You are not on a team, so cannot do this.");
+    }
+    return activeTeamMembership;
+}
+
+/**
+ * API endpoint for getting the user's team's saltines balance
+ */
+apiMethod(GET_SALTINES_BALANCE, async (data, app, user) => {
+    const db: BorisDatabase = app.get("db");
+    const activeTeamMembership = await requireActiveTeamMembership(db, user.id);
+    const status = await getSaltinesStatus(activeTeamMembership.team_id, db);
+    return {
+        saltinesBalance: status.balance,
+        saltinesEarnedAllTime: status.earned,
+    };
+});

--- a/common/api.ts
+++ b/common/api.ts
@@ -152,3 +152,15 @@ export type StepResponseRequest = (
     |MultipleChoiceStepResponseRequest
 );
 export const STEP_RESPONSE: ApiMethod<StepResponseRequest, EmptyApiResponse> = {path: '/api/game/step', type: 'POST'};
+
+
+///////////////////////////////////////////////////////////////////////////////
+// market-api methods:
+
+
+/** GET_UI_STATE Request */
+export interface GetSaltinesBalanceResponse {
+    saltinesBalance: number;
+    saltinesEarnedAllTime: number;
+}
+export const GET_SALTINES_BALANCE: ApiMethod<NoRequestParameters, GetSaltinesBalanceResponse> = {path: '/api/market/saltines', type: 'GET'};

--- a/frontend/admin/scripts.tsx
+++ b/frontend/admin/scripts.tsx
@@ -194,6 +194,34 @@ export const DocumentationAndStyles = (props: {}) => (
 `.trim()}</pre></code>
 
 
+            <h2>Award Saltines Step</h2>
+            <p>
+                This step can award saltines to the team. You must specify how
+                many were earned, and how many could have been earned.
+                If you are using if conditions, you should include an 'award'
+                step in each possible branch of the script, even if it's
+                awarding 0 saltines, to ensure the total possible count is
+                correct.
+            </p>
+            <h3>Example:</h3>
+            <code><pre>{`
+- step: goto
+  name: wrong
+  if: +VAR('guess') < 10
+# Here the user got it right:
+- step: award
+  earned: 10
+  possible: 10
+- step: goto
+  name: end
+# Here the user got it wrong:
+- step: award
+  earned: 0
+  possible: 10
+- step: target
+  name: end
+`.trim()}</pre></code>
+
             <h2>Pause Step</h2>
             <p>
                 A pause step pauses for the specified number of seconds.

--- a/frontend/admin/scripts.tsx
+++ b/frontend/admin/scripts.tsx
@@ -46,7 +46,7 @@ export const DocumentationAndStyles = (props: {}) => (
 
         <div style={{fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif'}}>
             <h1>Documentation</h1>
-            <p>BORIS scripts are written in <a href="https://en.wikipedia.org/wiki/YAML">YAML</a>, and consist of a list of "steps", and/or includes.</p>
+            <p>BORIS scripts are written in <a href="https://en.wikipedia.org/wiki/YAML">YAML</a>, and consist of a list of "steps", conditionals, and/or includes.</p>
             <h2>Steps</h2>
             <p>A typical step looks like:</p>
             <code><pre>{`
@@ -85,6 +85,31 @@ export const DocumentationAndStyles = (props: {}) => (
             <p>A script can include other scripts, combining multiple scripts into one larger script. For example:</p>
             <code><pre>- include: story1-1</pre></code>
             <p>Includes are not steps so cannot have an <code>if</code> condition or any other parameters.</p>
+
+            <h2>Conditionals</h2>
+            <p>To make writing scripts easier, scripts can include <code>if: then:</code>, <code>elif: then:</code>, and <code>else: then:</code> directives.</p>
+            <p>
+                These are self-explanatory. The <code>if</code> must be first, followed by zero or more <code>elif</code> directives, and finally an optional <code>else</code> directive.
+                Each directive must have the <code>then:</code> keyword followed by an indented list of steps to follow when the condition is true.
+            </p>
+            <h3>Example:</h3>
+            <code><pre>{`
+- if: VAR('name').toLowerCase() === "bob"
+  then:
+  - step: message
+    messages:
+    - You think he is Bob.
+- elif: VAR('name').toLowerCase() === "carl"
+  then:
+  - step: message
+    messages:
+    - You think he is Carl.
+- else:
+  then:
+  - step: message
+    messages:
+    - You are way off.
+`.trim()}</pre></code>
 
             <h2>Message Step</h2>
             <p>
@@ -205,21 +230,22 @@ export const DocumentationAndStyles = (props: {}) => (
             </p>
             <h3>Example:</h3>
             <code><pre>{`
-- step: goto
-  name: wrong
-  if: +VAR('guess') < 10
-# Here the user got it right:
-- step: award
-  earned: 10
-  possible: 10
-- step: goto
-  name: end
-# Here the user got it wrong:
-- step: award
-  earned: 0
-  possible: 10
-- step: target
-  name: end
+- if: VAR('wantsSaltines') === 'yes'
+  then:
+  - step: message
+    messages:
+    - Ok, awarding you 3 saltines
+  - step: award
+    earned: 3
+    possible: 3
+- else:
+  then:
+  - step: message
+    messages:
+    - Ok, awarding you 0 saltines
+  - step: award
+    earned: 0
+    possible: 3
 `.trim()}</pre></code>
 
             <h2>Pause Step</h2>

--- a/frontend/global/state/team-state-actions.ts
+++ b/frontend/global/state/team-state-actions.ts
@@ -1,7 +1,7 @@
 import {Dispatch} from 'redux';
 import { OtherTeamMember } from '../../../common/models';
 import { callApi } from '../../api';
-import { LEAVE_TEAM } from '../../../common/api';
+import { LEAVE_TEAM, GET_SALTINES_BALANCE } from '../../../common/api';
 
 //// Team State Actions
 
@@ -10,6 +10,7 @@ export enum TeamStateActions {
     LEAVE_TEAM = 'G_TS_LEAVE_TEAM', // The user is no longer on a team
     TEAM_MEMBERS_CHANGED = 'G_TS_TEAM_CHANGED', // The members on this team, or the user's admin status, has changed.
     JOIN_TEAM = 'G_TS_JOIN_TEAM', // The user is now on a team
+    UPDATE_SALTINES_BALANCE = 'G_TS_UPDATE_SALTINES', // We have updated the team's saltines balance
 }
 const Actions = TeamStateActions;
 
@@ -28,8 +29,13 @@ interface TeamMembersChangedAction {
     isTeamAdmin: boolean;
     otherTeamMembers: Array<OtherTeamMember>;
 }
+interface UpdateSaltinesBalanceAction {
+    type: TeamStateActions.UPDATE_SALTINES_BALANCE;
+    saltinesBalance: number;
+    saltinesEarnedAllTime: number;
+}
 
-export type TeamStateActionsType = LeaveTeamAction|JoinTeamAction|TeamMembersChangedAction;
+export type TeamStateActionsType = LeaveTeamAction|JoinTeamAction|TeamMembersChangedAction|UpdateSaltinesBalanceAction;
 
 //// Action Creators
 
@@ -37,5 +43,17 @@ export function leaveTeam() {
     return async (dispatch: Dispatch<{}>, getState: () => {}) => {
         await callApi(LEAVE_TEAM, {});
         dispatch<TeamStateActionsType>({type: Actions.LEAVE_TEAM});
+    };
+}
+
+/** Asynchronously update the data about how many saltines this team has earned. */
+export function updateSaltinesBalance() {
+    return async (dispatch: Dispatch<{}>, getState: () => {}) => {
+        const data = await callApi(GET_SALTINES_BALANCE, {});
+        dispatch<TeamStateActionsType>({
+            type: Actions.UPDATE_SALTINES_BALANCE,
+            saltinesBalance: data.saltinesBalance,
+            saltinesEarnedAllTime: data.saltinesEarnedAllTime,
+        });
     };
 }

--- a/frontend/global/state/team-state.ts
+++ b/frontend/global/state/team-state.ts
@@ -14,6 +14,8 @@ export class TeamState extends Record({
     teamCode: null as string|null,
     teamName: "NO TEAM",
     isTeamAdmin: false,
+    saltinesBalance: 0,
+    saltinesEarnedAllTime: 0,
     otherTeamMembers: [] as Array<OtherTeamMember>,
 }) {
     get hasJoinedTeam(): boolean {
@@ -43,6 +45,11 @@ export function teamStateReducer(state?: TeamState, action?: AnyAction): TeamSta
         return state.merge({
             isTeamAdmin: action.isTeamAdmin,
             otherTeamMembers: action.otherTeamMembers,
+        });
+    case Actions.UPDATE_SALTINES_BALANCE:
+        return state.merge({
+            saltinesBalance: action.saltinesBalance,
+            saltinesEarnedAllTime: action.saltinesEarnedAllTime,
         });
     case Actions.LEAVE_TEAM:
         // User has left a team (they're still associated with that team, just not "currently" online for that team):

--- a/frontend/lobby/team.tsx
+++ b/frontend/lobby/team.tsx
@@ -3,14 +3,13 @@ import * as React from 'react';
 import { connect, DispatchProp } from 'react-redux';
 
 import { RootState } from '../global/state';
-import { Actions } from './lobby-state-actions';
-import { Scenario, OtherTeamMember } from '../../common/models';
-import { AnyAction } from '../global/actions';
+import { OtherTeamMember } from '../../common/models';
 import { RpcClientConnectionStatus } from '../rpc-client/rpc-client-actions';
 
 import { Prompt } from '../prompt/prompt';
 
 import * as saltine from './images/saltine.svg';
+import { updateSaltinesBalance } from '../global/state/team-state-actions';
 
 interface TeamRowProps {
     details: OtherTeamMember,
@@ -93,8 +92,8 @@ interface OwnProps {
 interface Props extends OwnProps, DispatchProp<RootState> {
     teamCode: string;
     teamName: string;
-    totalPoints: number;
-    totalPointsAllTime: number;
+    saltinesBalance: number;
+    saltinesBalanceAllTime: number;
     myName: string;
     isTeamAdmin: boolean;
     isOnline: boolean;
@@ -113,7 +112,10 @@ class _TeamComponent extends React.PureComponent<Props, State> {
             teamView: true,
             editingTeam: false,
             showPrompt: false
-        })
+        });
+
+        // Update the saltines balance:
+        this.props.dispatch(updateSaltinesBalance());
     }
 
     public render() {
@@ -128,8 +130,8 @@ class _TeamComponent extends React.PureComponent<Props, State> {
                     <h1>{this.props.teamName}</h1>
                     <div className="saltines-count">
                         <h3>Saltines</h3>
-                        <p><img height="20" width="20" src={saltine} alt="Saltine" /><span>{this.props.totalPoints}</span>(current balance)</p>
-                        <p><img height="20" width="20" src={saltine} alt="Saltine" /><span>{this.props.totalPointsAllTime}</span>(earned all-time)</p>
+                        <p><img height="20" width="20" src={saltine} alt="Saltine" /><span>{this.props.saltinesBalance}</span>(current balance)</p>
+                        <p><img height="20" width="20" src={saltine} alt="Saltine" /><span>{this.props.saltinesBalanceAllTime}</span>(earned all-time)</p>
                     </div>
                     {/* <div className="rankings-snapshot">
                         <h3>Rank</h3>
@@ -189,15 +191,14 @@ class _TeamComponent extends React.PureComponent<Props, State> {
 }
 
 export const TeamComponent = connect((state: RootState, ownProps: OwnProps) => {
-    const selectedScenarioId = state.lobbyState.showScenarioDetails;
     return {
         myName: state.userState.firstName,
         teamCode: state.teamState.teamCode,
         teamName: state.teamState.teamName,
         isTeamAdmin: state.teamState.isTeamAdmin,
         isOnline: state.rpcClientState.status === RpcClientConnectionStatus.Connected,
-        totalPoints: 70,
-        totalPointsAllTime: 90,
+        saltinesBalance: state.teamState.saltinesBalance,
+        saltinesBalanceAllTime: state.teamState.saltinesEarnedAllTime,
         otherTeamMembers: state.teamState.otherTeamMembers,
     };
 })(_TeamComponent);


### PR DESCRIPTION
This adds a step that can award saltines.

This displays the current amount of saltines for the team in the team info page.

This also adds a new `if`/`elif`/`then` syntax which makes writing scripts much easier. Behind the scenes, these get rewritten to use `goto` and `target` steps.

Example script:
```
- step: message
  messages:
  - Hello from BORIS! This script will award your team some saltines.
  - Do you want some saltines?
- step: choice
  key: wantsSaltines
  correct: yes
  choices:
  - yes: Yes
  - no: No

- if: VAR('wantsSaltines') === 'yes'
  then:
  - step: message
    messages:
    - Ok, awarding you 3 saltines
  - step: award
    earned: 3
    possible: 3
- else:
  then:
  - step: message
    messages:
    - Ok, awarding you 0 saltines
  - step: award
    earned: 0
    possible: 3

- step: pause
  for: 2
```