### PR TITLE
Set variables from scripts, use variables in messages

### DIFF
--- a/backend/db/schema/test-data.sql
+++ b/backend/db/schema/test-data.sql
@@ -71,6 +71,16 @@ INSERT INTO scripts (name, script_yaml) VALUES
   key: chooseXtoEndGame
   choices:
     - x: Done
+'),
+
+('test-set-var-script', '---
+- step: message
+  messages:
+  - [''"You have played this scenario " + VAR("num_times_played", 0) + " times"'']
+- step: set
+  scope: team
+  key: num_times_played
+  to: VAR(''num_times_played'', 0) + 1
 ')
 
 ;

--- a/backend/game/step.ts
+++ b/backend/game/step.ts
@@ -1,5 +1,5 @@
 import { AnyUiState, StepType } from "../../common/game";
-import { GameManagerStepInterface, GameManager } from "./manager";
+import { GameManagerStepInterface } from "./manager";
 import { GameVar, GameVarScope } from "./vars";
 import { StepResponseRequest } from "../../common/api";
 import { SafeError } from "../routes/api-utils";
@@ -116,5 +116,9 @@ export abstract class Step {
         if (!this.manager.gameActive) {
             throw new Error("Skipping rest of step run() - game is over.");
         }
+    }
+
+    protected safeEvalScriptExpression(jsExpression: string) {
+        return this.manager.safeEvalScriptExpression(jsExpression);
     }
 }

--- a/backend/game/steps/loader.ts
+++ b/backend/game/steps/loader.ts
@@ -10,6 +10,7 @@ import { TargetStep } from "./target-step";
 import { AssignRolesStep } from "./assign-roles";
 import { BulletinStep } from "./bulletin";
 import { AwardSaltinesStep } from "./award-saltines";
+import { SetVariableStep } from "./set-step";
 
 export function loadStepFromData(data: any, id: number, manager: GameManagerStepInterface): Step {
     const {step, ...otherData} = data; // Remove the 'step' key from the data; 'step' is the step type.
@@ -23,6 +24,7 @@ export function loadStepFromData(data: any, id: number, manager: GameManagerStep
         case 'target': return new TargetStep(args);
         case 'award': return new AwardSaltinesStep(args);
         case 'bulletin': return new BulletinStep(args);
+        case 'set': return new SetVariableStep(args);
         case 'assignroles': return new AssignRolesStep(args);
         default: throw new Error(`Unable to load type with step type "${step}".`);
     }

--- a/backend/game/steps/message-step-test.ts
+++ b/backend/game/steps/message-step-test.ts
@@ -9,14 +9,19 @@ const stepYaml = `---
     - Funny how music put times in perspective
     - Add a soundtrack to your life and perfect it.
 `;
-const getStep = () => MockGameManager.loadStepFromYaml(stepYaml);
+const stepYamlWithJsExpressions = `---
+- step: message
+  messages:
+    - normal string message
+    - [("This is " + " a JS expression")]
+`;
 
 const MESSAGE_DELAY = 1000;
 
 describe("Message Step tests", () => {
 
     it("returns a null UI state at first, then the messages appear one by one over time", async () => {
-        const step = getStep();
+        const step = MockGameManager.loadStepFromYaml(stepYaml);
         const runPromise = step.run();
 
         expect(step.getUiState()).toEqual(null);
@@ -45,6 +50,28 @@ describe("Message Step tests", () => {
             messages: [
                 "Funny how music put times in perspective",
                 "Add a soundtrack to your life and perfect it.",
+            ],
+        });
+        expect(step.isComplete).toBe(true);
+    });
+
+    it("Can evaluate JavaScript expressions", async () => {
+        const step = MockGameManager.loadStepFromYaml(stepYamlWithJsExpressions);
+        step.run();
+
+        expect(step.getUiState()).toEqual(null);
+        expect(step.isComplete).toBe(false);
+
+        // Jest timer mocking isn't working with the asynchronous nature of run()
+        // so we have to delay this test case in real time :/
+        await new Promise(resolve => setTimeout(resolve, MESSAGE_DELAY * 2 + 150));
+
+        expect(step.getUiState()).toEqual({
+            stepId: 1,
+            type: StepType.MessageStep,
+            messages: [
+                "normal string message",
+                'MOCK JS RESULT OF: ("This is " + " a JS expression")',
             ],
         });
         expect(step.isComplete).toBe(true);

--- a/backend/game/steps/set-step-integration-test.ts
+++ b/backend/game/steps/set-step-integration-test.ts
@@ -1,0 +1,62 @@
+import 'jest';
+import { getUserIdWithRoleForTeam } from './assign-roles';
+import { BorisDatabase, getDB } from '../../db/db';
+import { GameManager } from '../manager';
+import { createTeam } from '../../test-lib/test-data';
+import { DBScenario } from '../../db/models';
+import { AnyNotification, NotificationType } from '../../../common/notifications';
+import { AnyUiState, StepType } from '../../../common/game';
+
+describe("Set Variable Step Integration tests", () => {
+    let db: BorisDatabase;
+    let scenario: DBScenario;
+    let testContext: {db: BorisDatabase, publishEventToUsers: (userIds: number[], event: AnyNotification) => void};
+    let messageQueue: {userId: number, stepIndex: number, stepUi: AnyUiState}[];
+    beforeAll(async () => {
+        db = await getDB();
+        scenario = (await db.scenarios.insert({
+            is_active: true,
+            name: "Test Scenario",
+            script: 'test-set-var-script',
+        }));
+    });
+    afterAll(async () => {
+        await db.instance.$pool.end();
+        });
+    beforeEach(async () => {
+        messageQueue = [];
+        testContext = {
+            db: db,
+            publishEventToUsers: (userIds: number[], event: AnyNotification) => {
+                if (event.type === NotificationType.GAME_UI_UPDATE) {
+                    for (const userId of userIds) {
+                        messageQueue.push({userId, stepIndex: event.stepIndex, stepUi: event.newStepUi});
+                    }
+                }
+            },
+        }
+    });
+    afterEach(async () => {
+    });
+
+    it("Updates variables as expected", async () =>{
+        const {teamId} = await createTeam(db, 3);
+        const {manager} = await GameManager.startGame(teamId, scenario.id, testContext);
+        // Play through the whole script - there's no interaction in this test script.
+        await manager.allPendingStepsFlushed();
+
+        const expectMessage = (msg, expected) => {
+            expect(msg.stepUi.type === StepType.MessageStep);
+            expect(msg.stepUi.messages).toEqual(expected);
+        }
+
+        expectMessage(messageQueue[0], ["You have played this scenario 0 times"]);
+        expect(manager.gameActive).toBe(false);
+
+        messageQueue = [];
+        const manager2 = (await GameManager.startGame(teamId, scenario.id, testContext)).manager;
+        await manager2.allPendingStepsFlushed();
+        expectMessage(messageQueue[0], ["You have played this scenario 1 times"]);
+        expect(manager2.gameActive).toBe(false);
+    }, 5000);
+});

--- a/backend/game/steps/set-step.ts
+++ b/backend/game/steps/set-step.ts
@@ -1,0 +1,52 @@
+import { StepType } from "../../../common/game";
+import { Step } from "../step";
+import { SafeError } from "../../routes/api-utils";
+import { GameVarScope, GameVar } from "../vars";
+
+/**
+ * Set Variable Step: Sets a team or game-scoped variable.
+ * 
+ * Example:
+ * - step: set
+ *   key: story
+ *   scope: team
+ *   to: VAR('story', 0) + 1
+ */
+export class SetVariableStep extends Step {
+    public static readonly stepType: StepType = StepType.Internal;
+    readonly settings: {
+        key: string,
+        scope: 'team'|'game',
+        to: string,
+    };
+
+    async run() {
+        const gameVar: GameVar<any> = {
+            key: this.settings.key,
+            scope: this.settings.scope === 'game' ? GameVarScope.Game : GameVarScope.Team,
+            default: undefined
+        };
+        await this.setVar(gameVar, (oldVal) => this.safeEvalScriptExpression(this.settings.to));
+    }
+
+    protected parseConfig(config: any): any {
+        if (typeof config.key !== 'string') {
+            throw new SafeError(`A 'set' step must have a 'key' parameter specifying the variable name.`);
+        }
+        if (typeof config.to !== 'string') {
+            throw new SafeError(`A 'set' step must have a 'to' parameter specifying the value expression.`);
+        }
+        if (config.scope !== 'team' && config.scope !== 'game') {
+            throw new SafeError(`A 'set' step must have 'scope' key set to either 'game' or 'team'.`);
+        }
+        return config;
+    }
+
+    getUiState(): null {
+        return null;
+    }
+
+    public get isComplete() {
+        return true;
+    }
+}

--- a/backend/routes/admin-api-test.ts
+++ b/backend/routes/admin-api-test.ts
@@ -1,7 +1,7 @@
 import 'jest';
 import { TestClient, TestServer, TestUserData } from '../test-lib/utils';
 import { BorisDatabase } from '../db/db';
-import { LIST_USERS, LIST_TEAMS, LIST_SCENARIOS, LIST_GAMES, LIST_SCRIPTS, CREATE_SCRIPT, EDIT_SCRIPT, GET_SCRIPT, GET_SCENARIO, CREATE_SCENARIO, EDIT_SCENARIO } from './admin-api';
+import { LIST_USERS, LIST_TEAMS, LIST_SCENARIOS, LIST_GAMES, LIST_SCRIPTS, CREATE_SCRIPT, EDIT_SCRIPT, GET_SCRIPT, GET_SCENARIO, CREATE_SCENARIO, EDIT_SCENARIO, GET_TEAM } from './admin-api';
 import { ApiMethod } from '../../common/api';
 import { createTeam, TEST_SCENARIO_ID } from '../test-lib/test-data';
 
@@ -69,6 +69,24 @@ describe("Admin API tests", () => {
         describe("List Teams (GET /api/admin/teams)", async () => {
 
             checkSecurity(LIST_TEAMS);
+
+        });
+        describe("Team Details (GET /api/admin/teams/:id)", async () => {
+
+            checkSecurity(GET_TEAM, {id: "1"});
+
+            it("Returns team data", async () => {
+                const {team, teamId} = await createTeam(server.app.get("db") as BorisDatabase, 3);
+                const response = await client.callApi(GET_TEAM, {id: String(teamId)});
+                expect(response).toEqual({
+                    id: teamId,
+                    name: team.name,
+                    organization: team.organization,
+                    code: team.code,
+                    created: JSON.stringify(team.created).replace(/"/g, ''),
+                    game_vars: team.game_vars,
+                });
+            });
 
         });
     });

--- a/backend/routes/admin-api.ts
+++ b/backend/routes/admin-api.ts
@@ -80,6 +80,29 @@ export const LIST_TEAMS = defineListMethod<Team>('teams', async (criteria, query
     return queryWithCount(db.teams, criteria, {...queryOptions, fields: ['id', 'name', 'organization', 'code', 'created']});
 });
 
+
+
+export const GET_TEAM: ApiMethod<{id: string}, Team&{game_vars: any}> = {path: `/api/admin/teams/:id`, type: 'GET'};
+defineMethod(GET_TEAM, async (data, app, user) => {
+    const db: BorisDatabase = app.get("db");
+    const id = parseInt(data.id, 10);
+    if (isNaN(id)) {
+        throw new SafeError(`Invalid team ID.`);
+    }
+    const team = await db.teams.findOne(id);
+    if (team === null) {
+        throw new SafeError(`Team ${id} not found.`, 404);
+    }
+    return {
+        id: team.id,
+        name: team.name,
+        organization: team.organization,
+        code: team.code,
+        created: team.created,
+        game_vars: team.game_vars,
+    };
+});
+
 interface ScenarioWithScript extends Scenario {
     script: string;
 }

--- a/backend/test-lib/mock-game-manager.ts
+++ b/backend/test-lib/mock-game-manager.ts
@@ -35,6 +35,10 @@ export class MockGameManager implements GameManagerStepInterface {
         return newValue;
     }
 
+    public safeEvalScriptExpression(jsExpression: string) {
+        return `MOCK JS RESULT OF: ${jsExpression}`;
+    }
+
     /** A helper method for test cases to use to load Steps from YAML strings */
     static loadStepFromYaml(yamlData: string, manager = new MockGameManager()): Step {
         const data = yaml.safeLoad(yamlData);

--- a/frontend/admin/app.tsx
+++ b/frontend/admin/app.tsx
@@ -5,7 +5,7 @@ import { Admin, Resource } from 'react-admin';
 
 import { dataProvider } from './data-provider';
 import { UserList } from './users';
-import { TeamList } from './teams';
+import { TeamList, TeamShow } from './teams';
 import { ScenarioList, ScenarioShow, ScenarioEdit, ScenarioCreate } from './scenarios';
 import { ScriptsList, ScriptEdit, ScriptCreate } from './scripts';
 import { GameList } from './games';
@@ -15,7 +15,7 @@ const history = createHistory({ basename: '/admin' });
 const App = () => (
     <Admin title="Boris Admin" dataProvider={dataProvider} history={history}>
         <Resource name="users"     list={UserList} />
-        <Resource name="teams"     list={TeamList} />
+        <Resource name="teams"     list={TeamList}     show={TeamShow} />
         <Resource name="scenarios" list={ScenarioList} show={ScenarioShow} edit={ScenarioEdit} create={ScenarioCreate} />
         <Resource name="scripts"   list={ScriptsList}                      edit={ScriptEdit}   create={ScriptCreate} />
         <Resource name="games"     list={GameList} />

--- a/frontend/admin/scripts.tsx
+++ b/frontend/admin/scripts.tsx
@@ -253,6 +253,25 @@ export const DocumentationAndStyles = (props: {}) => (
     possible: 3
 `.trim()}</pre></code>
 
+            <h2>Set Variable Step</h2>
+            <p>
+                A set variable step lets you set a variable. You must specify the scope of the variable, which is either
+                "game" or "team" (the difference is that team variables last across multiple games/scenarios, and "game"
+                variables are only available within the current game/scenario). The "key" paramter is the name of the
+                variable to set, and the "to" parameter specifies the value as a JavaScript expression.
+            </p>
+            <h3>Example:</h3>
+            <code><pre>{`
+- step: message
+  messages:
+  - ['"You have played this scenario " + VAR("num_times_played", 0) + " times"']
+# Increase the number of times played by 1:
+- step: set
+  scope: team
+  key: num_times_played
+  to: VAR('num_times_played', 0) + 1
+`.trim()}</pre></code>
+
             <h2>Pause Step</h2>
             <p>
                 A pause step pauses for the specified number of seconds.

--- a/frontend/admin/scripts.tsx
+++ b/frontend/admin/scripts.tsx
@@ -62,12 +62,12 @@ export const DocumentationAndStyles = (props: {}) => (
                 <dt><code>if: <em>(condition)</em></code></dt>
                 <dd>
                     <p>A JavaScript expression that determines whether or not any given player should see this step.
-                    Script variables can be accessed using the <code>VAR(name)</code> function.
+                    Script variables can be accessed using the <code>VAR(name, [optional default])</code> function.
                     You can use the <code>ROLE(roleId)</code> function to check if the current user has been assigned a particular role.</p>
                     You can use the <code>NUM_PLAYERS</code> variable to get the number of players.
                     <p>Examples:</p>
                     <p><code>if: ROLE('D')</code> (only send this step to the user who is the doomsayer)</p>
-                    <p><code>if: VAR('saltines') >= 10</code> (only display this step if the team has earned at least ten saltines).</p>
+                    <p><code>if: VAR('saltines', 0) >= 10</code> (only display this step if the team has earned at least ten saltines).</p>
                 </dd>
                 <dt><code>parallel: yes</code></dt>
                 <dd>
@@ -120,6 +120,10 @@ export const DocumentationAndStyles = (props: {}) => (
                 The character is optional and defaults to <code>boris</code>.
                 It can also be set to <code>backfeed</code>, <code>clarence</code>, or <code>nameless</code> (for the nameless organization).
             </p>
+            <p>
+                A message can also optionally contain a JavaScript expression, if you surround it with <code>['</code> and <code>']</code>.
+                If doing this, check your work using a YAML editor, because it's easy to get the syntax wrong.
+            </p>
             <h3>Example:</h3>
             <code><pre>{`
 - step: message
@@ -128,6 +132,7 @@ export const DocumentationAndStyles = (props: {}) => (
   - Let’s begin the scenario.
   - First, walk to the ocean.
   - Then, yell at the moon.
+  - ['"You have played this scenario " + VAR("num_times_played", 0) + " times"']
 `}</pre></code>
 
             <h2>[Multiple] Choice Step</h2>

--- a/frontend/admin/teams.tsx
+++ b/frontend/admin/teams.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { List, Datagrid, EmailField, NumberField, TextField, DateField } from 'react-admin';
+import { List, Datagrid, NumberField, TextField, DateField, ShowButton, ShowController, ShowView, SimpleShowLayout } from 'react-admin';
 
 export const TeamList = (props: any) => (
     <List title="All teams" {...props}>
@@ -9,6 +9,26 @@ export const TeamList = (props: any) => (
             <TextField source="organization" />
             <TextField source="code" />
             <DateField source="created" />
+            <ShowButton />
         </Datagrid>
     </List>
+);
+
+export const TeamShow = (props: any) => (
+    <ShowController {...props}>
+        {(controllerProps: any) => 
+            <ShowView {...props} {...controllerProps}>
+                <SimpleShowLayout>
+                    <NumberField source="id" />
+                    <TextField source="name" />
+                    <TextField source="organization" />
+                    <TextField source="code" />
+                    <DateField source="created" />
+                    {controllerProps.record && controllerProps.record.game_vars && Object.keys(controllerProps.record.game_vars).map(k =>
+                        <TextField key={k} source={`game_vars.${k}`} label={k} />
+                    )}
+                </SimpleShowLayout>
+            </ShowView>
+        }
+    </ShowController>
 );


### PR DESCRIPTION
Here is a script that tests these features:

```yaml
- step: message
  messages:
  - Hello from BORIS!
  - ['"You have played this scenario " + VAR("num_times_played", 0) + " times"']
# Increase the number of times played by 1:
- step: set
  scope: team
  key: num_times_played
  to: VAR('num_times_played', 0) + 1
# Wait for the user's input before ending the game:
- step: choice
  key: chooseXtoEndGame
  choices:
    - x: Cool
```