### PR TITLE
Fix: Sometimes saltines were not being awarded correctly

### DIFF
--- a/backend/game/manager.ts
+++ b/backend/game/manager.ts
@@ -390,7 +390,7 @@ export class GameManager implements GameManagerStepInterface {
                 for (const userId of userIdsForEarliestStep) {
                     await this.pushStepSeenByUser(userId, earliestStepId);
                     const step = this.steps.get(earliestStepId);
-                    if (step.isComplete) {
+                    if (step.isComplete && this.stepRunPromisesByStepId.has(step.id)) { // Check stepRunPromises because some steps 
                         // Somehow this step is already complete. Possibly it is a parallel step and
                         // another user already completed it.
                         if (step.getUiState() !== null) {

--- a/backend/game/steps/award-saltines.ts
+++ b/backend/game/steps/award-saltines.ts
@@ -37,11 +37,13 @@ export function getSaltinesEarnedInGame(gameManager: GameManager) {
 export class AwardSaltinesStep extends Step {
     public static readonly stepType: StepType = StepType.Internal;
     readonly settings: AwardSaltinesStepSettings;
+    public static readonly hasRun: GameVar<boolean> = {key: 'hasRun', scope: GameVarScope.Step, default: false};
 
     async run() {
-        this.setVar(SALTINES_EARNED_ALL_TIME, oldAmount => oldAmount + this.settings.earned);
-        this.setVar(SALTINES_EARNED_THIS_GAME, oldAmount => oldAmount + this.settings.earned);
-        this.setVar(SALTINES_POSSIBLE_THIS_GAME, oldAmount => oldAmount + this.settings.possible);
+        await this.setVar(SALTINES_EARNED_ALL_TIME, oldAmount => oldAmount + this.settings.earned);
+        await this.setVar(SALTINES_EARNED_THIS_GAME, oldAmount => oldAmount + this.settings.earned);
+        await this.setVar(SALTINES_POSSIBLE_THIS_GAME, oldAmount => oldAmount + this.settings.possible);
+        await this.setVar(AwardSaltinesStep.hasRun, true);
     }
 
     protected parseConfig(config: any): AwardSaltinesStepSettings {
@@ -65,6 +67,6 @@ export class AwardSaltinesStep extends Step {
     }
 
     public get isComplete() {
-        return true;
+        return this.getVar(AwardSaltinesStep.hasRun);
     }
 }

--- a/backend/game/steps/set-step.ts
+++ b/backend/game/steps/set-step.ts
@@ -14,6 +14,7 @@ import { GameVarScope, GameVar } from "../vars";
  */
 export class SetVariableStep extends Step {
     public static readonly stepType: StepType = StepType.Internal;
+    public static readonly hasRun: GameVar<boolean> = {key: 'hasRun', scope: GameVarScope.Step, default: false};
     readonly settings: {
         key: string,
         scope: 'team'|'game',
@@ -27,6 +28,7 @@ export class SetVariableStep extends Step {
             default: undefined
         };
         await this.setVar(gameVar, (oldVal) => this.safeEvalScriptExpression(this.settings.to));
+        await this.setVar(SetVariableStep.hasRun, true);
     }
 
     protected parseConfig(config: any): any {
@@ -47,6 +49,6 @@ export class SetVariableStep extends Step {
     }
 
     public get isComplete() {
-        return true;
+        return this.getVar(SetVariableStep.hasRun);
     }
 }

--- a/backend/routes/admin-api.ts
+++ b/backend/routes/admin-api.ts
@@ -125,7 +125,7 @@ interface ScenarioWithScript extends Scenario {
 
 export const LIST_SCENARIOS = defineListMethod<ScenarioWithScript>('scenarios', async (criteria, queryOptions, db, app, user) => {
     const fields = ['id', 'name', 'duration_min', 'difficulty', 'start_point_name', 'is_active', 'script', 'description_html', 'start_point', ];
-    const {data, count} = await queryWithCount(db.scenarios, {...criteria, is_active: true}, {...queryOptions, fields});
+    const {data, count} = await queryWithCount(db.scenarios, {...criteria}, {...queryOptions, fields});
     const scenarios = data.map( s => ({...s, start_point: {lat: s.start_point.x, lng: s.start_point.y}}) );
     return { data: scenarios, count, };
 });


### PR DESCRIPTION
This fixes a bug whereby saltines were not being awarded in some cases.

This also makes inactive scenarios appear in the admin, so that they can be reactivated.