### PR TITLE
Include the full URL of the login link in plain text

### DIFF
--- a/backend/routes/login-register.ts
+++ b/backend/routes/login-register.ts
@@ -39,8 +39,8 @@ async function sendLoginLinkToUser(app: express.Application, email: string) {
     // Load the template file:
     const htmlTemplate = String(await readFileAsync(`${__dirname}/login-template.html`));
     const html = (htmlTemplate
-        .replace('{{login_url}}', `${config.app_url}/auth/login/${code}`)
-        .replace('{{first_name}}', user.first_name)
+        .replace(/{{login_url}}/g, `${config.app_url}/auth/login/${code}`)
+        .replace(/{{first_name}}/g, user.first_name)
     );
     // And send it out via email:
     await sendMail({

--- a/backend/routes/login-template.html
+++ b/backend/routes/login-template.html
@@ -3,3 +3,5 @@
 <p>On behalf of the Citizens for a Friendlier Post-Apocalypse, thanks for registering for Apocalypse Made Easy!</p>
 
 <p><a href="{{login_url}}" style="font-weight: bold;">Click here to log in.</a></p>
+
+<p>If you're having problems logging in, paste this URL into a different browser: {{login_url}}</p>


### PR DESCRIPTION
Since some people couldn't use their default browser and didn't know how to copy a link's address on their mobile device.