### PR TITLE
Fix behavior of Actualized market status

### DIFF
--- a/backend/routes/market-api.ts
+++ b/backend/routes/market-api.ts
@@ -47,8 +47,10 @@ export async function getMarketStatus(teamId: number, userId: number, db: BorisD
         status = playerIsTheBurdened ? MarketStatus.Forced : MarketStatus.ForcedForOtherPlayer;
     } else if (scenariosComplete > 1 && scenariosComplete < 3) {
         status = playerIsTheBurdened ? MarketStatus.Open : MarketStatus.Taped;
-    } else if (scenariosComplete >= 3) {
-        status = playerIsTheBurdened ? MarketStatus.Actualized : MarketStatus.Boarded;
+    } else if (scenariosComplete == 3) {
+        status = playerIsTheBurdened ? MarketStatus.Actualized : MarketStatus.Taped;
+    } else if (scenariosComplete >= 4) {
+        status = MarketStatus.Boarded;
     }
     return status;
 }

--- a/common/api.ts
+++ b/common/api.ts
@@ -177,8 +177,8 @@ export const enum MarketStatus {
     Open = 'O', // The market is open and the current player may go buy a punchcard if they wish to
     AlreadyBought = 'A', // The player is the burdened and has _just_ purchased a punchard
     Taped = 'T', // The player is not the burdened so cannot enter the market
-    Boarded = 'X', // The team has completed at least 3 scenarios so are permanently locked out of the market.
-    Actualized = 'Z', // The current user is "The Burdened" and the team has completed at least 3 scenarios so are permanently locked out of the market.
+    Boarded = 'X', // The team has completed at least 4 scenarios so are permanently locked out of the market.
+    Actualized = 'Z', // The current user is "The Burdened" and the team has completed at least 3 scenarios. The Burdened can still enter the market.
 };
 
 export interface GetTeamMarketVarsResponse {

--- a/frontend/global/state/team-state.ts
+++ b/frontend/global/state/team-state.ts
@@ -24,7 +24,7 @@ export class TeamState extends Record({
         return this.teamCode !== null;
     }
     get allowMarket(): boolean {
-        return this.marketStatus === MarketStatus.Forced || this.marketStatus === MarketStatus.Open;
+        return this.marketStatus === MarketStatus.Forced || this.marketStatus === MarketStatus.Open || this.marketStatus === MarketStatus.Actualized;
     }
     get forceMarket(): boolean {
         return this.marketStatus === MarketStatus.Forced || this.marketStatus === MarketStatus.ForcedForOtherPlayer;


### PR DESCRIPTION
Fix:
> After a team has completed 3 scenarios, the 'actualized' graphic should show - which it does. But at that point the Burdened should still be able to enter the market. Currently they can't.
>
> Then after a 4th scenario, no users should be allowed to enter the market - it should be boarded up or taped or whatever.