### PR TITLE
Provide a link from the app to the marketing site

### DIFF
--- a/frontend/registration/home.tsx
+++ b/frontend/registration/home.tsx
@@ -6,6 +6,7 @@ export class HomeComponent extends React.PureComponent {
         return <div>
             <h1>Would you survive the end of the world?</h1>
             <p>After finishing the Apocalypse Made Easy! training course, the answer will be most definitely perhaps.</p>
+            <p>Use the buttons above to register or login so you can get started. Or perhaps you want to <a href="https://apocalypsemadeeasy.com/">learn more about how it works</a>? </p>
             <img src={friends} alt="Apocalypse Made Easy! | Surviving is Better with Friends" />
         </div>;
     }


### PR DESCRIPTION
This adds a link here so that if anyone ends up on the `play` site without knowing what this is about, they can find the main site.

![screen shot 2018-11-05 at 6 03 47 pm](https://user-images.githubusercontent.com/945577/48038406-515eb180-e125-11e8-8cb7-0975c42a32e1.png)
