### PR TITLE
Add tabs to switch cities

### DIFF
--- a/backend/db/migrate.ts
+++ b/backend/db/migrate.ts
@@ -19,6 +19,7 @@ export async function migrate() {
             '001-initial-up',
             '002-admin-users',
             '003-scripts',
+            '004-scenario-city',
         ];
         for (const migrationId of migrations) {
             const filePath = path.join(__dirname, 'schema', `${migrationId}.sql`);

--- a/backend/db/models.ts
+++ b/backend/db/models.ts
@@ -55,6 +55,7 @@ export function scenarioFromDbScenario(s: DBScenario): Scenario {
         start_point_name: s.start_point_name,
         description_html: s.description_html,
         start_point: {lat: s.start_point.x, lng: s.start_point.y},
+        city: s.city,
     };
 }
 

--- a/backend/db/schema/004-scenario-city.sql
+++ b/backend/db/schema/004-scenario-city.sql
@@ -1,0 +1,1 @@
+ALTER TABLE scenarios ADD COLUMN city text NOT NULL DEFAULT 'vancouver';

--- a/backend/db/schema/test-data.sql
+++ b/backend/db/schema/test-data.sql
@@ -85,6 +85,6 @@ INSERT INTO scripts (name, script_yaml) VALUES
 
 ;
 
-INSERT INTO scenarios (id, name, script, duration_min, difficulty, start_point_name, start_point, description_html) VALUES 
-    (123, 'Test Scenario', 'test-script', 30, 'easy', 'SE False Creek', '(49.273373, -123.102657)', '<p>This route (approximately 700m) starts in front of Science World and follows the Seawall to the plaza area in front of Craft Beer Market.</p>')
+INSERT INTO scenarios (id, name, script, duration_min, difficulty, start_point_name, start_point, city, description_html) VALUES 
+    (123, 'Test Scenario', 'test-script', 30, 'easy', 'SE False Creek', '(49.273373, -123.102657)', 'vancouver', '<p>This route (approximately 700m) starts in front of Science World and follows the Seawall to the plaza area in front of Craft Beer Market.</p>')
 ;

--- a/backend/routes/admin-api-test.ts
+++ b/backend/routes/admin-api-test.ts
@@ -123,6 +123,7 @@ describe("Admin API tests", () => {
                     script: "test-script",
                     start_point: {lat: 49.273373, lng: -123.102657},
                     start_point_name: "SE False Creek",
+                    city: 'vancouver',
                 });
             });
         });
@@ -139,6 +140,7 @@ describe("Admin API tests", () => {
                     start_point: {lat: 15.2, lng: 35.15},
                     start_point_name: 'a place',
                     script: 'test-script',
+                    city: 'vancouver',
                 });
                 expect(typeof createResponse.id).toBe('number');
                 expect(createResponse.name).toEqual("A New Test Scenario");
@@ -160,6 +162,7 @@ describe("Admin API tests", () => {
                     is_active: false,
                     start_point: {lat: 15.2, lng: 35.15},
                     description_html: 'test description',
+                    city: 'vancouver',
                 });
                 expect(createResponse.is_active).toBe(false);
                 const updateResponse = await client.callApi(EDIT_SCENARIO, {
@@ -167,12 +170,14 @@ describe("Admin API tests", () => {
                     name: "A Modified Test Scenario",
                     is_active: true,
                     start_point: {lat: 18.2, lng: 15.15},
+                    city: 'kelowna',
                     // We don't specify a script nor description_html which should leave it unchanged.
                 });
                 expect(updateResponse.id).toEqual(createResponse.id);
                 expect(updateResponse.name).toEqual("A Modified Test Scenario");
                 expect(updateResponse.is_active).toBe(true);
                 expect(updateResponse.start_point).toEqual({lat: 18.2, lng: 15.15});
+                expect(updateResponse.city).toEqual('kelowna');
                 expect(updateResponse.script).toEqual('test-script');
                 expect(updateResponse.description_html).toEqual('test description');
                 const getResponse = await client.callApi(GET_SCENARIO, {id: String(createResponse.id)});

--- a/backend/routes/admin-api.ts
+++ b/backend/routes/admin-api.ts
@@ -172,7 +172,7 @@ function adminScenarioFromDBScenario(scenarioData: DBScenario): AdminScenario {
 
 function cleanScenarioDataForInsertOrUpdate(data: Partial<AdminScenarioNoId>): Partial<DBScenarioForInsertOrUpdate> {
     const cleanData: Partial<DBScenarioForInsertOrUpdate> = {};
-    for (const field of ['name', 'is_active', 'script', 'start_point_name', 'duration_min', 'description_html']) {
+    for (const field of ['name', 'is_active', 'script', 'start_point_name', 'duration_min', 'description_html', 'city']) {
         if ((data as any)[field] !== undefined) { (cleanData as any)[field] = (data as any)[field]; };
     }
     if (data.start_point !== undefined) {

--- a/common/models.ts
+++ b/common/models.ts
@@ -17,6 +17,7 @@ export interface BaseScenario {
     difficulty: 'easy'|'med'|'hard';
     start_point_name: string;
     description_html: string;
+    city: string;
 }
 
 export interface Scenario extends BaseScenario {

--- a/frontend/admin/scenarios.tsx
+++ b/frontend/admin/scenarios.tsx
@@ -29,6 +29,7 @@ export const ScenarioList = (props: any) => (
             <BooleanField source="is_active" />
             <NumberField source="duration_min" />
             <TextField source="difficulty" />
+            <TextField source="city" />
             <ShowButton />
             <EditButton />
         </Datagrid>
@@ -47,6 +48,7 @@ export const ScenarioShow = (props: any) => (
             <BooleanField source="is_active" />
             <NumberField source="duration_min" />
             <TextField source="difficulty" />
+            <TextField source="city" />
         </SimpleShowLayout>
     </Show>
 );
@@ -66,6 +68,11 @@ const editForm = <SimpleForm redirect={false}>
         { id: 'easy', name: 'easy' },
         { id: 'med', name: 'med' },
         { id: 'hard', name: 'hard' },
+    ]} />
+    <SelectInput source="city" choices={[
+        { id: 'vancouver', name: 'vancouver' },
+        { id: 'kelowna', name: 'kelowna' },
+        { id: 'hidden', name: 'hidden' },
     ]} />
 </SimpleForm>;
 

--- a/frontend/lobby/choose-scenario.tsx
+++ b/frontend/lobby/choose-scenario.tsx
@@ -27,6 +27,7 @@ interface Props extends OwnProps, DispatchProp<RootState> {
 }
 interface State {
     showMap: boolean;
+    showVancouver: boolean;
 }
 
 class _ChooseScenarioComponent extends React.PureComponent<Props, State> {
@@ -34,6 +35,7 @@ class _ChooseScenarioComponent extends React.PureComponent<Props, State> {
         super(props);
         this.state = ({
             showMap: true,
+            showVancouver: true,
         });
         // Update the vars that affect whether we show the market:
         this.props.dispatch(updateMarketVars());
@@ -46,6 +48,7 @@ class _ChooseScenarioComponent extends React.PureComponent<Props, State> {
     }
     
     public render() {
+        const { showVancouver } = this.state;
         if (this.props.teamCode === null) {
             return <div>Error: you must have joined a team to see the scenario list.</div>;
         }
@@ -70,29 +73,33 @@ class _ChooseScenarioComponent extends React.PureComponent<Props, State> {
         }
 
         return <div>
-            <h1>Choose Scenario</h1>
-            {this.props.marketStatus === MarketStatus.Hidden ? 
-                (<p>Share your team code <span className='mono'>{this.props.teamCode}</span> to recruit more team members. You'll need 2-5 people to play. Then choose a scenario and head to its start point!</p>) : 
-                (<MarketButton status={this.props.marketStatus} onClick={this.handleMarketButtonClicked} />)
-            }
-            <div className="scenario-grid">
-                <LoadingSpinnerComponent state={this.props.scenariosLoadState} onTryAgain={this.tryLoadingScenarios}>
-                    {this.props.scenarios.map(s =>
-                        <div key={s.id} className={'scenario-choice id-' + s.id}>
-                            <div className="scenario-info">
-                                <span className={s.difficulty}>{s.difficulty}</span><br />
-                                <span>{s.duration_min} mins</span>
-                                <h4>{s.name}</h4>
-                                <span>Start at {s.start_point_name}</span>
-                            </div>
-                            <div className="scenario-buttons">
-                                <button className="inverted" onClick={() => { this.showScenarioDetails(s.id); }}>Info?</button>
-                                <button onClick={() => { this.startScenario(s.id); }}>Start!</button>
-                            </div>
-                        </div>
-                    )}
-                </LoadingSpinnerComponent>
-            </div>
+          <h1>Choose Scenario</h1>
+          {this.props.marketStatus === MarketStatus.Hidden ? 
+            (<p>Share your team code <span className='mono'>{this.props.teamCode}</span> to recruit more team members. You'll need 2-5 people to play. Then choose your city, pick a scenario, and head to its start point!</p>) : 
+            (<MarketButton status={this.props.marketStatus} onClick={this.handleMarketButtonClicked} />)
+          }
+          <nav className="tabs city">
+            <button value="vancouver" onClick={this.chooseCity} className={showVancouver ? 'active' : ''}>Vancouver</button>
+            <button onClick={this.chooseCity} className={showVancouver ? '' : 'active'}>Kelowna</button>
+          </nav>
+          <div className={showVancouver ? 'scenario-grid vancouver' : 'scenario-grid kelowna'}>
+            <LoadingSpinnerComponent state={this.props.scenariosLoadState} onTryAgain={this.tryLoadingScenarios}>
+              {this.props.scenarios.map(s =>
+                <div key={s.id} className={'scenario-choice id-' + s.id}>
+                  <div className="scenario-info">
+                    <span className={s.difficulty}>{s.difficulty}</span><br />
+                    <span>{s.duration_min} mins</span>
+                    <h4>{s.name}</h4>
+                    <span>Start at {s.start_point_name}</span>
+                  </div>
+                  <div className="scenario-buttons">
+                    <button className="inverted" onClick={() => { this.showScenarioDetails(s.id); }}>Info?</button>
+                      <button onClick={() => { this.startScenario(s.id); }}>Start!</button>
+                    </div>
+                  </div>
+              )}
+            </LoadingSpinnerComponent>
+          </div>
         </div>;
     }
 
@@ -118,6 +125,12 @@ class _ChooseScenarioComponent extends React.PureComponent<Props, State> {
             this.props.dispatch<AnyAction>({type: Actions.SHOW_MARKET});
         }
     }
+
+    @bind private chooseCity(event: React.MouseEvent<HTMLButtonElement>) {
+      const vancouver = event.currentTarget.value;
+      vancouver ? this.setState({ showVancouver: true }) : this.setState({ showVancouver: false })
+
+  }
 }
 
 export const ChooseScenarioComponent = connect((state: RootState, ownProps: OwnProps) => {

--- a/frontend/lobby/choose-scenario.tsx
+++ b/frontend/lobby/choose-scenario.tsx
@@ -27,15 +27,17 @@ interface Props extends OwnProps, DispatchProp<RootState> {
 }
 interface State {
     showMap: boolean;
-    showVancouver: boolean;
+    chosenCity: string;
 }
+
+const LAST_CITY = 'last-city'; // Key to remember which city the user chose via localStorage
 
 class _ChooseScenarioComponent extends React.PureComponent<Props, State> {
     constructor(props: Props) {
         super(props);
         this.state = ({
             showMap: true,
-            showVancouver: true,
+            chosenCity: localStorage.getItem(LAST_CITY) || 'vancouver',
         });
         // Update the vars that affect whether we show the market:
         this.props.dispatch(updateMarketVars());
@@ -48,7 +50,6 @@ class _ChooseScenarioComponent extends React.PureComponent<Props, State> {
     }
     
     public render() {
-        const { showVancouver } = this.state;
         if (this.props.teamCode === null) {
             return <div>Error: you must have joined a team to see the scenario list.</div>;
         }
@@ -71,6 +72,8 @@ class _ChooseScenarioComponent extends React.PureComponent<Props, State> {
                 <div className="scenario-description" dangerouslySetInnerHTML={{__html: selectedScenario.description_html}}></div>
             </div>
         }
+        
+        const { chosenCity } = this.state;
 
         return <div>
           <h1>Choose Scenario</h1>
@@ -79,12 +82,13 @@ class _ChooseScenarioComponent extends React.PureComponent<Props, State> {
             (<MarketButton status={this.props.marketStatus} onClick={this.handleMarketButtonClicked} />)
           }
           <nav className="tabs city">
-            <button value="vancouver" onClick={this.chooseCity} className={showVancouver ? 'active' : ''}>Vancouver</button>
-            <button onClick={this.chooseCity} className={showVancouver ? '' : 'active'}>Kelowna</button>
+            <button value="vancouver" onClick={this.chooseCity} className={chosenCity === 'vancouver' ? 'active' : ''}>Vancouver</button>
+            <button value="kelowna" onClick={this.chooseCity} className={chosenCity === 'kelowna' ? 'active' : ''}>Kelowna</button>
+            {/* <button value="hidden" onClick={this.chooseCity} className={chosenCity === 'hidden' ? 'active' : ''}>Hidden</button> */}
           </nav>
-          <div className={showVancouver ? 'scenario-grid vancouver' : 'scenario-grid kelowna'}>
+          <div className='scenario-grid'>
             <LoadingSpinnerComponent state={this.props.scenariosLoadState} onTryAgain={this.tryLoadingScenarios}>
-              {this.props.scenarios.map(s =>
+              {this.props.scenarios.filter(s => s.city === chosenCity).map(s =>
                 <div key={s.id} className={'scenario-choice id-' + s.id}>
                   <div className="scenario-info">
                     <span className={s.difficulty}>{s.difficulty}</span><br />
@@ -127,9 +131,9 @@ class _ChooseScenarioComponent extends React.PureComponent<Props, State> {
     }
 
     @bind private chooseCity(event: React.MouseEvent<HTMLButtonElement>) {
-      const vancouver = event.currentTarget.value;
-      vancouver ? this.setState({ showVancouver: true }) : this.setState({ showVancouver: false })
-
+      const city = event.currentTarget.value;
+      this.setState({ chosenCity: city });
+      localStorage.setItem(LAST_CITY, city);
   }
 }
 

--- a/frontend/lobby/lobby.scss
+++ b/frontend/lobby/lobby.scss
@@ -50,11 +50,13 @@
           }
           button.active {
             border-top: 1px solid lighten($black, 30%);
+            border-left: 1px solid lighten($black, 30%);
+            border-right: 1px solid lighten($black, 30%);
               &:first-child {
-                border-right: 1px solid lighten($black, 30%);
+                border-left: 0 none;
               }
               &:last-child {
-                border-left: 1px solid lighten($black, 30%);
+                border-right: 0 none;
               }
           }
       }
@@ -95,22 +97,6 @@
                             }
                     }
             }
-        &.kelowna {
-          // When Kelowna is active, hide Vancouver scenarios
-          .scenario-choice {
-            &.id-1, &.id-2, &.id-3, &.id-4 {
-              display: none;
-            }
-          }
-        }
-        &.vancouver {
-          .scenario-choice {
-            &.id-6, &.id-7, &.id-8, &.id-9 {
-              display: none;
-            }
-          }
-        }
-
     }
 
     p {
@@ -187,10 +173,6 @@
     }
     .id-4 {
         background-image: url('./images/bg-home.svg')
-    }
-    // Hide testing scenario
-    .id-5 {
-        display: none !important;
     }
 
     .teams {

--- a/frontend/lobby/lobby.scss
+++ b/frontend/lobby/lobby.scss
@@ -30,6 +30,36 @@
             }
     }
 
+    nav.tabs {
+      margin: -1rem -1rem 1rem -1rem;
+      display: flex;
+      button {
+          background: darken($grey, 10%);
+          color: lighten($black, 25%);
+          padding: 1rem 1.25rem;
+          flex: 1;
+              &.active {
+                  background: none;
+                  color: $black;
+              }
+      }
+      &.city {
+        margin: 1rem -1rem;
+          button {
+            border-top: 1px solid $white;
+          }
+          button.active {
+            border-top: 1px solid lighten($black, 30%);
+              &:first-child {
+                border-right: 1px solid lighten($black, 30%);
+              }
+              &:last-child {
+                border-left: 1px solid lighten($black, 30%);
+              }
+          }
+      }
+    }
+
     .scenario-grid {
         display: flex;
         flex-wrap: wrap;
@@ -65,6 +95,22 @@
                             }
                     }
             }
+        &.kelowna {
+          // When Kelowna is active, hide Vancouver scenarios
+          .scenario-choice {
+            &.id-1, &.id-2, &.id-3, &.id-4 {
+              display: none;
+            }
+          }
+        }
+        &.vancouver {
+          .scenario-choice {
+            &.id-6, &.id-7, &.id-8, &.id-9 {
+              display: none;
+            }
+          }
+        }
+
     }
 
     p {
@@ -157,21 +203,6 @@
                     padding: 0.25rem 0.5rem;
                     margin-left: 0.5rem;
                 }
-        }
-
-        nav.tabs {
-            margin: -1rem -1rem 1rem -1rem;
-            display: flex;
-            button {
-                background: darken($grey, 10%);
-                color: lighten($black, 25%);
-                padding: 1rem 1.25rem;
-                flex: 1;
-                    &.active {
-                        background: none;
-                        color: $black;
-                    }
-            }
         }
 
         .saltines-count {

--- a/frontend/lobby/team.tsx
+++ b/frontend/lobby/team.tsx
@@ -149,11 +149,6 @@ class _TeamComponent extends React.PureComponent<Props, State> {
                         <p><img height="20" width="20" src={saltine} alt="Saltine" /><span>{this.props.saltinesBalance}</span>(current balance)</p>
                         <p><img height="20" width="20" src={saltine} alt="Saltine" /><span>{this.props.saltinesBalanceAllTime}</span>(earned all-time)</p>
                     </div>
-                    {/* <div className="rankings-snapshot">
-                        <h3>Rank</h3>
-                        <button onClick={this.switchTab}><sup>#</sup>2<span>in Vancouver</span></button>
-                        <button onClick={this.switchTab}><sup>#</sup>78<span>in Canada</span></button>
-                    </div> */}
                     <h3>Your team {this.props.isTeamAdmin && <button onClick={this.editTeam}>{this.state.editingTeam ? 'Done Editing' : 'Edit Team'}</button>}</h3>
                     <ul className="team">
                         <TeamMemberRow isMe={true} details={{name: this.props.myName, id: 0, online: this.props.isOnline, isAdmin: this.props.isTeamAdmin}} editable={false} />


### PR DESCRIPTION
Switching tabs shows/hides scenarios with CSS based on the `.scenario-choice` IDs, which maybe isn't ideal. Should there instead be a new database column to specify a scenario's city?

![image](https://user-images.githubusercontent.com/1463539/50791006-5c44d800-1275-11e9-859f-d4a027fe01d0.png)