### PR TITLE
Allow deleting things from the admin

### DIFF
--- a/backend/routes/api-utils.ts
+++ b/backend/routes/api-utils.ts
@@ -61,10 +61,10 @@ export function makeApiHelper(router: express.Router, mountPath: RegExp, require
 
     return function apiMethodMaker<RequestType, ResponseType>(def: ApiMethod<RequestType, ResponseType>, fn: (data: RequestType, app: express.Application, user?: User) => Promise<ResponseType>) {
         const path = def.path.replace(mountPath, '');
-        if (def.type === 'POST' || def.type === 'PUT') {
+        if (def.type === 'POST' || def.type === 'PUT' || def.type === 'DELETE') {
             const handler = apiErrorWrapper(async (req: express.Request, res: express.Response) => {
                 await checkUserLoggedIn(req);
-                if (!req.body) {
+                if (!req.body && def.type !== 'DELETE') {
                     throw new SafeError("Missing JSON body.");
                 }
                 const data: RequestType = {...req.body, ...req.params};
@@ -75,6 +75,8 @@ export function makeApiHelper(router: express.Router, mountPath: RegExp, require
                 router.post(path, handler);
             } else if (def.type === 'PUT') {
                 router.put(path, handler);
+            } else if (def.type === 'DELETE') {
+                router.delete(path, handler);
             }
         } else if (def.type === 'GET') {
             router.get(path, apiErrorWrapper(async (req: express.Request, res: express.Response) => {

--- a/backend/test-lib/utils.ts
+++ b/backend/test-lib/utils.ts
@@ -83,6 +83,9 @@ export class TestClient {
         } else if (method.type === 'PUT') {
             response = await this.httpClient.put(path, {json: data});
             body = response.body;
+        } else if (method.type === 'DELETE') {
+            response = await this.httpClient.delete(path, {json: data});
+            body = response.body;
         }
         return body;
     }

--- a/common/api.ts
+++ b/common/api.ts
@@ -16,7 +16,7 @@ export interface ApiErrorResponse {
 
 export interface ApiMethod<RequestType, ResponseType> {
     path: string;
-    type: 'POST'|'GET'|'PUT';
+    type: 'POST'|'GET'|'PUT'|'DELETE';
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/frontend/admin/app.tsx
+++ b/frontend/admin/app.tsx
@@ -4,20 +4,20 @@ import createHistory from 'history/createBrowserHistory';
 import { Admin, Resource } from 'react-admin';
 
 import { dataProvider } from './data-provider';
-import { UserList } from './users';
+import { UserList, UserShow } from './users';
 import { TeamList, TeamShow } from './teams';
 import { ScenarioList, ScenarioShow, ScenarioEdit, ScenarioCreate } from './scenarios';
-import { ScriptsList, ScriptEdit, ScriptCreate } from './scripts';
+import { ScriptsList, ScriptEdit, ScriptCreate, ScriptShow } from './scripts';
 import { GameList } from './games';
 
 const history = createHistory({ basename: '/admin' });
 
 const App = () => (
     <Admin title="Boris Admin" dataProvider={dataProvider} history={history}>
-        <Resource name="users"     list={UserList} />
+        <Resource name="users"     list={UserList}     show={UserShow} />
         <Resource name="teams"     list={TeamList}     show={TeamShow} />
         <Resource name="scenarios" list={ScenarioList} show={ScenarioShow} edit={ScenarioEdit} create={ScenarioCreate} />
-        <Resource name="scripts"   list={ScriptsList}                      edit={ScriptEdit}   create={ScriptCreate} />
+        <Resource name="scripts"   list={ScriptsList}  show={ScriptShow}   edit={ScriptEdit}   create={ScriptCreate} />
         <Resource name="games"     list={GameList} />
     </Admin>
 );

--- a/frontend/admin/scripts.tsx
+++ b/frontend/admin/scripts.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { List, Datagrid, TextField, EditButton, Edit, Create, SimpleForm, TextInput, LongTextInput } from 'react-admin';
+import { List, Datagrid, TextField, EditButton, Edit, Create, Show, ShowButton, SimpleShowLayout, SimpleForm, TextInput, LongTextInput } from 'react-admin';
 
 export const ScriptsList = (props: any) => (
     <List title="All Scripts" {...props}>
         <Datagrid>
             <TextField source="name" />
+            <ShowButton />
             <EditButton />
         </Datagrid>
     </List>
@@ -22,6 +23,14 @@ export const ScriptCreate = (props: any) => (
     </div>
 );
 
+export const ScriptShow = (props: any) => (
+    <Show {...props}>
+        <SimpleShowLayout>
+            <TextField source="name" />
+            <TextField source="script_yaml" />
+        </SimpleShowLayout>
+    </Show>
+);
 
 export const ScriptEdit = (props: any) => (
     <div>

--- a/frontend/admin/teams.tsx
+++ b/frontend/admin/teams.tsx
@@ -14,6 +14,7 @@ import {
     CardActions,
     ListButton,
     RefreshButton,
+    DeleteButton,
     Button,
 } from 'react-admin';
 
@@ -53,6 +54,7 @@ const TeamShowActions = (props: any) => (
     <CardActions style={cardActionStyle}>
         <ListButton basePath={props.basePath} />
         <RefreshButton />
+        <DeleteButton basePath={props.basePath} record={props.data} resource={props.resource} />
         {/* Add your custom actions */}
         <Button color="secondary" onClick={() => { resetTeam(props.data.id); }}>Reset Vars (!)</Button>
     </CardActions>

--- a/frontend/admin/users.tsx
+++ b/frontend/admin/users.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { List, Datagrid, EmailField, TextField, DateField } from 'react-admin';
+import { List, Datagrid, BooleanField, EmailField, TextField, DateField, NumberField, Show, ShowButton, SimpleShowLayout } from 'react-admin';
 
 export const UserList = (props: any) => (
     <List title="All users" {...props}>
@@ -8,6 +8,23 @@ export const UserList = (props: any) => (
             <TextField source="first_name" />
             <EmailField source="email" />
             <DateField source="created" />
+            <ShowButton />
         </Datagrid>
     </List>
+);
+
+export const UserShow = (props: any) => (
+    <Show {...props}>
+        <SimpleShowLayout>
+            <TextField source="id" />
+            <TextField source="first_name" />
+            <EmailField source="email" />
+            <DateField source="created" />
+            <NumberField label="Age" source="survey_data.age" />
+            <TextField label="Occupation" source="survey_data.occupation" />
+            <TextField label="Gender" source="survey_data.gender" />
+            <BooleanField label="Works in Tech" source="survey_data.workInTech" />
+            <BooleanField label="Consented to terms" source="survey_data.hasConsented" />
+        </SimpleShowLayout>
+    </Show>
 );


### PR DESCRIPTION
Allows admin users to delete teams, scenarios, and scripts from the admin.

Note: it doesn't prompt to ask you to confirm, but it does let you undo the delete if you click "Undo" near the bottom of the screen within a few seconds of having clicked delete.