### PR TITLE
User online status fix

### DIFF
--- a/backend/websocket/connections.ts
+++ b/backend/websocket/connections.ts
@@ -46,7 +46,6 @@ export function rpcHandler(ws: WebSocket, req: express.Request) {
     setUserOnline(req.user.id).then(() => {
         notifyTeamStatusChangedForUser(app, req.user.id);
     });
-    ws.on('pong', () => { setUserOnline(req.user.id); });
     // This sharedWebSocketClientState is local to this node.js process so may not be aware of ALL connections,
     // which is the responsibility of the redis USERS_ONLINE tracker.
     sharedWebSocketClientState.allConnections.add(connectionState);
@@ -93,8 +92,9 @@ export function rpcHandler(ws: WebSocket, req: express.Request) {
     // ping/pong messages, we have to send it as a JSON RPC message
     connectionState.pingTimer = setInterval(async () => {
         try {
-            console.log(`sending ping`);
-            const reply = await peer.notify('ping');
+            //console.log(`sending ping to peer ${connectionState.index}`);
+            await peer.notify('ping');
+            setUserOnline(req.user.id);
         } catch (err) {
             console.error(`Error while sending ws ping: ${err}`);
             ws.close();

--- a/frontend/lobby/choose-scenario.tsx
+++ b/frontend/lobby/choose-scenario.tsx
@@ -111,6 +111,13 @@ class _ChooseScenarioComponent extends React.PureComponent<Props, State> {
         this.tryLoadingScenarios();
     }
 
+    public componentDidUpdate(prevProps: Props, prevState: State) {
+        if (this.props.selectedScenarioId !== prevProps.selectedScenarioId) {
+            // When the screen changes, scroll back to the top.
+            window.scrollTo({top: 0});
+        }
+    }
+
     @bind private tryLoadingScenarios() {
         this.props.dispatch(loadScenarios());
     }

--- a/frontend/lobby/lobby.tsx
+++ b/frontend/lobby/lobby.tsx
@@ -78,6 +78,13 @@ class _LobbyComponent extends React.PureComponent<Props, State> {
         </RpcConnectionStatusIndicator>;
     }
 
+    public componentDidUpdate(prevProps: Props, prevState: State) {
+        if (this.props.mode != prevProps.mode) {
+            // When the screen changes, scroll back to the top.
+            window.scrollTo({top: 0});
+        }
+    }
+
     @bind private handleDeclineResearchPrompt() {
         this.props.dispatch(markPreSurveySeen());
     }


### PR DESCRIPTION
This fixes a bug introduced in #79, which causes any user to appear to be offline after 60s, even though the connection is kept open and they're still online.

It also improves the lobby UI by scrolling to the top of the screen whenever the user changes to a new page.