### PR TITLE
Add Google Tag Manager to app

### DIFF
--- a/backend/views/react-app.pug
+++ b/backend/views/react-app.pug
@@ -9,7 +9,16 @@ html
         link(href="https://fonts.googleapis.com/css?family=Kanit:700|Noto+Sans", rel="stylesheet")
         link(href=`${resUrl}/style.css?${styleCssHash}`, rel="stylesheet")
 
+        script.
+            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+            })(window,document,'script','dataLayer','GTM-KW3FPFT');
+
 body
+    noscript
+        iframe(src='https://www.googletagmanager.com/ns.html?id=GTM-KW3FPFT', height='0', width='0', style='display: none; visibility: hidden;')
     #app-container
     script(crossorigin, src=`https://unpkg.com/react@${reactVersion}/umd/react.${reactBuild}.js`)
     script(crossorigin, src=`https://unpkg.com/react-dom@${reactVersion}/umd/react-dom.${reactBuild}.js`)


### PR DESCRIPTION
Hi @bradenmacdonald we're wanting to add GTM to track conversions from the marketing campaign. This seemed to work on lobby screens but I couldn't start the game locally because the scenarios don't show up on the **Choose Scenario** screen.

I assume because they need to be assigned to a city, but when I try to do that in the admin I get this error: `Error: column "city" of relation "scenarios" does not exist`. I tried resetting the db but still same issue. 