### PR TITLE
Sort scenarios by specified order

### DIFF
--- a/backend/db/migrate.ts
+++ b/backend/db/migrate.ts
@@ -20,6 +20,7 @@ export async function migrate() {
             '002-admin-users',
             '003-scripts',
             '004-scenario-city',
+            '005-scenario-order',
         ];
         for (const migrationId of migrations) {
             const filePath = path.join(__dirname, 'schema', `${migrationId}.sql`);

--- a/backend/db/models.ts
+++ b/backend/db/models.ts
@@ -56,6 +56,7 @@ export function scenarioFromDbScenario(s: DBScenario): Scenario {
         description_html: s.description_html,
         start_point: {lat: s.start_point.x, lng: s.start_point.y},
         city: s.city,
+        order: s.order,
     };
 }
 

--- a/backend/db/schema/005-scenario-order.sql
+++ b/backend/db/schema/005-scenario-order.sql
@@ -1,0 +1,1 @@
+ALTER TABLE scenarios ADD COLUMN "order" integer NOT NULL DEFAULT 100;

--- a/backend/db/schema/test-data.sql
+++ b/backend/db/schema/test-data.sql
@@ -85,6 +85,6 @@ INSERT INTO scripts (name, script_yaml) VALUES
 
 ;
 
-INSERT INTO scenarios (id, name, script, duration_min, difficulty, start_point_name, start_point, city, description_html) VALUES 
-    (123, 'Test Scenario', 'test-script', 30, 'easy', 'SE False Creek', '(49.273373, -123.102657)', 'vancouver', '<p>This route (approximately 700m) starts in front of Science World and follows the Seawall to the plaza area in front of Craft Beer Market.</p>')
+INSERT INTO scenarios (id, name, script, duration_min, difficulty, start_point_name, start_point, city, "order", description_html) VALUES 
+    (123, 'Test Scenario', 'test-script', 30, 'easy', 'SE False Creek', '(49.273373, -123.102657)', 'vancouver', 100, '<p>This route (approximately 700m) starts in front of Science World and follows the Seawall to the plaza area in front of Craft Beer Market.</p>')
 ;

--- a/backend/routes/admin-api-test.ts
+++ b/backend/routes/admin-api-test.ts
@@ -162,6 +162,7 @@ describe("Admin API tests", () => {
                     start_point: {lat: 49.273373, lng: -123.102657},
                     start_point_name: "SE False Creek",
                     city: 'vancouver',
+                    order: 100,
                 });
             });
         });
@@ -179,6 +180,7 @@ describe("Admin API tests", () => {
                     start_point_name: 'a place',
                     script: 'test-script',
                     city: 'vancouver',
+                    order: 15,
                 });
                 expect(typeof createResponse.id).toBe('number');
                 expect(createResponse.name).toEqual("A New Test Scenario");
@@ -201,6 +203,7 @@ describe("Admin API tests", () => {
                     start_point: {lat: 15.2, lng: 35.15},
                     description_html: 'test description',
                     city: 'vancouver',
+                    order: 50,
                 });
                 expect(createResponse.is_active).toBe(false);
                 const updateResponse = await client.callApi(EDIT_SCENARIO, {
@@ -218,6 +221,7 @@ describe("Admin API tests", () => {
                 expect(updateResponse.city).toEqual('kelowna');
                 expect(updateResponse.script).toEqual('test-script');
                 expect(updateResponse.description_html).toEqual('test description');
+                expect(updateResponse.order).toEqual(50);
                 const getResponse = await client.callApi(GET_SCENARIO, {id: String(createResponse.id)});
                 expect(getResponse).toEqual(updateResponse);
             });
@@ -235,6 +239,7 @@ describe("Admin API tests", () => {
                     start_point_name: 'a place',
                     script: 'test-script',
                     city: 'vancouver',
+                    order: 500,
                 });
                 await client.callApi(DELETE_SCENARIO, {id: String(createResponse.id)});
                 const promise = client.callApi(GET_SCENARIO, {id: String(createResponse.id)});

--- a/backend/routes/admin-api.ts
+++ b/backend/routes/admin-api.ts
@@ -172,8 +172,9 @@ interface ScenarioWithScript extends Scenario {
 }
 
 export const LIST_SCENARIOS = defineListMethod<ScenarioWithScript>('scenarios', async (filter, criteria, queryOptions, db, app, user) => {
-    const fields = ['id', 'name', 'duration_min', 'difficulty', 'start_point_name', 'is_active', 'script', 'description_html', 'start_point', ];
-    const {data, count} = await queryWithCount(db.scenarios, criteria, {...queryOptions, fields});
+    const fields = ['id', 'name', 'duration_min', 'difficulty', 'start_point_name', 'is_active', 'script', 'description_html', 'start_point', 'city', 'order'];
+    const defaultOrder = {order: [{field: 'city'}, {field: 'order'}, {field: 'name'}]};
+    const {data, count} = await queryWithCount(db.scenarios, criteria, {...defaultOrder, ...queryOptions, fields});
     const scenarios = data.map( s => ({...s, start_point: {lat: s.start_point.x, lng: s.start_point.y}}) );
     return { data: scenarios, count, };
 });
@@ -204,7 +205,7 @@ function adminScenarioFromDBScenario(scenarioData: DBScenario): AdminScenario {
 
 function cleanScenarioDataForInsertOrUpdate(data: Partial<AdminScenarioNoId>): Partial<DBScenarioForInsertOrUpdate> {
     const cleanData: Partial<DBScenarioForInsertOrUpdate> = {};
-    for (const field of ['name', 'is_active', 'script', 'start_point_name', 'duration_min', 'description_html', 'city']) {
+    for (const field of ['name', 'is_active', 'script', 'start_point_name', 'duration_min', 'description_html', 'city', 'order']) {
         if ((data as any)[field] !== undefined) { (cleanData as any)[field] = (data as any)[field]; };
     }
     if (data.start_point !== undefined) {

--- a/backend/routes/lobby-api.ts
+++ b/backend/routes/lobby-api.ts
@@ -19,7 +19,10 @@ const apiMethod = makeApiHelper(router, /^\/api\/lobby/, RequireUser.Required);
  */
 apiMethod(GET_SCENARIOS, async (data, app, user) => {
     const db: BorisDatabase = app.get("db");
-    const scenarios = await db.scenarios.find({is_active: true});
+    const scenarios = await db.scenarios.find(
+        {is_active: true},
+        {order: [{field: 'order'}, {field: 'name'}]} as any, // TODO: Fix massive.js type definitions 'order' field
+    );
     const cleanedScenarios: Array<Scenario> = scenarios.map( scenarioFromDbScenario );
     return {scenarios: cleanedScenarios};
 });

--- a/common/models.ts
+++ b/common/models.ts
@@ -18,6 +18,7 @@ export interface BaseScenario {
     start_point_name: string;
     description_html: string;
     city: string;
+    order: number;
 }
 
 export interface Scenario extends BaseScenario {

--- a/frontend/admin/scenarios.tsx
+++ b/frontend/admin/scenarios.tsx
@@ -30,6 +30,7 @@ export const ScenarioList = (props: any) => (
             <NumberField source="duration_min" />
             <TextField source="difficulty" />
             <TextField source="city" />
+            <NumberField source="order" />
             <ShowButton />
             <EditButton />
         </Datagrid>
@@ -49,6 +50,7 @@ export const ScenarioShow = (props: any) => (
             <NumberField source="duration_min" />
             <TextField source="difficulty" />
             <TextField source="city" />
+            <NumberField source="order" />
         </SimpleShowLayout>
     </Show>
 );
@@ -74,6 +76,7 @@ const editForm = <SimpleForm redirect={false}>
         { id: 'kelowna', name: 'kelowna' },
         { id: 'hidden', name: 'hidden' },
     ]} />
+    <NumberInput source="order" />
 </SimpleForm>;
 
 export const ScenarioEdit = (props: any) => (


### PR DESCRIPTION
This adds a new "Order" field for each scenario in the admin which can be used to adjust the order in which they appear. If two scenarios have the same Order number, they'll be sorted alphabetically.

Once you check this branch out, in VS Code you must go Tasks > Run Task > Apply Database Migrations.